### PR TITLE
Add authenticated routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default async function RootLayout({ children }: Props) {
           <AppRouterCacheProvider>
             <ThemeProvider>
               <AppBar />
-              <Box component="main" sx={{ my: 4 }}>
+              <Box component="main" sx={{ my: 8 }}>
                 {children}
               </Box>
             </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,55 @@
-import { Container, Typography } from '@mui/material';
+import { auth } from '@/config/auth';
+import {
+  Card,
+  CardContent,
+  Container,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { RedirectType, redirect } from 'next/navigation';
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
 
-export default function Home() {
+export default async function Dashboard() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/welcome', RedirectType.replace);
+  }
+
   return (
     <Container>
-      <Typography>Hello World</Typography>
+      <Stack spacing={4}>
+        <Card>
+          <CardContent>
+            <Typography variant="h1">Zero COventry</Typography>
+            <Stack
+              component={Link}
+              href="#"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="body2"
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: 'center' }}
+            >
+              <span>netzero.kausal.tech/coventry-netzero</span>
+              <BoxArrowUpRight size={14} />
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <div>
+          <Typography gutterBottom variant="h3" component="h2">
+            Data collection center
+          </Typography>
+          <Card>
+            <CardContent>
+              <Typography variant="h5">Another card...</Typography>
+            </CardContent>
+          </Card>
+        </div>
+      </Stack>
     </Container>
   );
 }

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -1,0 +1,12 @@
+import { Container, Typography } from '@mui/material';
+
+export default async function Dashboard() {
+  return (
+    <Container>
+      <Typography variant="h1">Welcome to NetZeroPaths</Typography>
+      <Typography variant="subtitle1">
+        Unauthenticated homepage route
+      </Typography>
+    </Container>
+  );
+}

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -43,7 +43,7 @@ export function AppBar() {
 
   const handleLogIn = () => {
     handleCloseAuthMenu();
-    signIn();
+    signIn(undefined, { callbackUrl: '/' });
   };
 
   const handleSignOut = () => {

--- a/theme/overrides.ts
+++ b/theme/overrides.ts
@@ -101,6 +101,9 @@ export function getOverrides(theme: Theme): ThemeOptions['components'] {
         root: {
           boxShadow: theme.customShadows.card,
           borderRadius: Number(theme.shape.borderRadius) * 2,
+          borderWidth: 1,
+          borderStyle: 'solid',
+          borderColor: theme.palette.grey[200],
           position: 'relative',
           zIndex: 0, // Fix Safari overflow: hidden with border radius
         },

--- a/theme/typography.ts
+++ b/theme/typography.ts
@@ -12,10 +12,8 @@ type FontBreakpoints = {
 
 export function responsiveFontSizes({ sm, md, lg }: FontBreakpoints) {
   return {
+    fontSize: pxToRem(sm),
     '@media (min-width:600px)': {
-      fontSize: pxToRem(sm),
-    },
-    '@media (min-width:900px)': {
       fontSize: pxToRem(md),
     },
     '@media (min-width:1200px)': {
@@ -34,37 +32,37 @@ export const typography: ThemeOptions['typography'] = {
     fontWeight: 800,
     lineHeight: 80 / 64,
     fontSize: pxToRem(40),
-    ...responsiveFontSizes({ sm: 52, md: 58, lg: 64 }),
+    ...responsiveFontSizes({ sm: 32, md: 40, lg: 48 }),
   },
   h2: {
     fontWeight: 800,
     lineHeight: 64 / 48,
     fontSize: pxToRem(32),
-    ...responsiveFontSizes({ sm: 40, md: 44, lg: 48 }),
+    ...responsiveFontSizes({ sm: 29, md: 34, lg: 40 }),
   },
   h3: {
     fontWeight: 700,
     lineHeight: 1.5,
     fontSize: pxToRem(24),
-    ...responsiveFontSizes({ sm: 26, md: 30, lg: 32 }),
+    ...responsiveFontSizes({ sm: 26, md: 30, lg: 33 }),
   },
   h4: {
     fontWeight: 700,
     lineHeight: 1.5,
     fontSize: pxToRem(20),
-    ...responsiveFontSizes({ sm: 20, md: 24, lg: 24 }),
+    ...responsiveFontSizes({ sm: 23, md: 25, lg: 28 }),
   },
   h5: {
     fontWeight: 700,
     lineHeight: 1.5,
     fontSize: pxToRem(18),
-    ...responsiveFontSizes({ sm: 19, md: 20, lg: 20 }),
+    ...responsiveFontSizes({ sm: 20, md: 22, lg: 23 }),
   },
   h6: {
     fontWeight: 700,
     lineHeight: 28 / 18,
     fontSize: pxToRem(17),
-    ...responsiveFontSizes({ sm: 18, md: 18, lg: 18 }),
+    ...responsiveFontSizes({ sm: 18, md: 18, lg: 19 }),
   },
   subtitle1: {
     fontWeight: 600,


### PR DESCRIPTION
Add two initial routes depending on authentication:
- Logged in users will see the dashboard at `/`
- Unauthenticated users will be redirected to the welcome page at `/welcome`

This ensures the welcome/ product page can be indexed by search engines, and still viewed by logged in users.

Also tweaked the theme and added some mock copy on the dashboard page.