### PR TITLE
Fix import edge case for measures with identical names in the same section

### DIFF
--- a/utils/csv-import/README.md
+++ b/utils/csv-import/README.md
@@ -1,0 +1,30 @@
+# CSV Import Utility
+
+## Purpose
+
+The CSV Import utility is designed to parse CSV (Comma-Separated Values) files exported from the NetZeroCities economic modelling Excel files containing measure data for a city's carbon reduction efforts. It maps the imported data to predefined measures using UUIDs from Kausal's database.
+
+- Parses CSV files containing measure data
+- Maps CSV rows to predefined measures using UUIDs
+- Handles multiple measures with the same name by considering parent sections and previous rows
+- Provides error handling for unmatched measures and general parsing issues
+
+1. `csv-import.tsx`: Contains the main parsing logic (`parseMeasuresCsv` function)
+2. `legacy-measure-map.json`: Defines the mapping between measure names, parent sections, and UUIDs. The names and section names must match the Excel sheet exactly.
+3. `csv-import.test.ts`: Contains unit tests for the CSV import functionality
+4. `data-request.csv.ts`: Contains a sample CSV data for testing and development
+5. `data-request-parsed-result.ts`: Contains the expected output for the sample CSV data
+
+## Data Structure
+
+The parsed measures are returned as a `Map` where:
+
+- The key is the UUID of the measure
+- The value is an object containing:
+  - `label`: The name of the measure
+  - `value`: The numerical value of the measure
+  - `comment`: Any comment associated with the measure
+
+## Sample Data
+
+The `data-request.csv.ts` file contains a sample CSV dataset that can be used for testing and development purposes. The `data-request-parsed-result.ts` file contains the expected output for this sample data, which is used in the unit tests to verify the correct functioning of the parser.

--- a/utils/csv-import/__mocks__/data-request-parsed-result.ts
+++ b/utils/csv-import/__mocks__/data-request-parsed-result.ts
@@ -182,11 +182,15 @@ export const EXPECTED_MEASURES = new Map([
   ],
   [
     '327a3e7e-0778-4098-b644-901533cfda3b',
-    { label: 'Of which less than 2 years old', value: 4, comment: '' },
+    { label: 'Of which less than 2 years old', value: 7, comment: '' },
   ],
   [
     'be4a0009-a06f-4b69-a22c-babf4c616980',
     { label: 'Heavy duty trucks >3.5 tonnes', value: 4410, comment: '' },
+  ],
+  [
+    'b03bcb8c-cb77-4d7a-bed4-2a0150090aa1',
+    { label: 'Of which less than 2 years old', value: 4, comment: '' },
   ],
   [
     'ada6b0d9-4da0-420e-9e0b-adf7d19421b2',

--- a/utils/csv-import/legacy-measure-map.json
+++ b/utils/csv-import/legacy-measure-map.json
@@ -186,6 +186,7 @@
   },
   {
     "name": "Of which less than 2 years old",
+    "previousRow": "Light duty trucks <3.5 tonnes",
     "parentSection": "Number of trucks registered within city",
     "uuid": "327a3e7e-0778-4098-b644-901533cfda3b"
   },
@@ -196,6 +197,7 @@
   },
   {
     "name": "Of which less than 2 years old",
+    "previousRow": "Heavy duty trucks >3.5 tonnes",
     "parentSection": "Number of trucks registered within city",
     "uuid": "b03bcb8c-cb77-4d7a-bed4-2a0150090aa1"
   },


### PR DESCRIPTION
Uses the previous row as context to determine the correct measure. Previously, the "Of which less than 2 years old" measures were not imported due to having the same name and being in the same section.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/0c16dc58-0451-4f66-b480-332e072c4a6d">