### PR TITLE
Improve color contrast for accessibility

### DIFF
--- a/theme/overrides.ts
+++ b/theme/overrides.ts
@@ -90,6 +90,8 @@ export function getOverrides(theme: Theme): ThemeOptions['components'] {
           '&:hover, &:focus': {
             borderWidth: 2,
           },
+          color: theme.palette.brand[700],
+          borderColor: theme.palette.brand[700],
         },
         sizeLarge: {
           minHeight: 48,
@@ -120,6 +122,13 @@ export function getOverrides(theme: Theme): ThemeOptions['components'] {
         },
       },
     },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          color: theme.palette.grey[700],
+        },
+      },
+    },
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
@@ -132,6 +141,23 @@ export function getOverrides(theme: Theme): ThemeOptions['components'] {
     MuiPaper: {
       defaultProps: {
         elevation: 0,
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          color: theme.palette.text.secondary,
+          '&.Mui-selected': {
+            color: theme.palette.brand[700],
+          },
+        },
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: theme.palette.brand[700],
+        },
       },
     },
     MuiTableCell: {


### PR DESCRIPTION
Axe Devtools detected a few color contrast issues on the Dashboard page.
* Overrode color styles for problematic elements to improve accessibility;
* Updated `InputLabel`, `Tabs`, and `Button` components.

Related Asana https://app.asana.com/0/1205310117865974/1207998595096496/f

<img width="1438" alt="Screen Shot 2024-08-11 at 14 03 44" src="https://github.com/user-attachments/assets/bdb1e048-b540-4075-bf59-a71091018b5b">
