### PR TITLE
Add number localisation based on http header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,6 +34,12 @@ type Props = {
 export default async function RootLayout({ children }: Props) {
   const session = await auth();
   const headersList = headers();
+  /**
+   * Extract the preferred language from the 'accept-language' header. Languages are split by
+   * a comma, but may also include a semi-colon to denote the quality factor weighting. 
+   * Example: "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7"
+   * This code will return "en-US" as it's the first language in the list
+   */
   const preferredLanguage =
     headersList.get('accept-language')?.split(',')[0]?.split(';')[0] || 'en';
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { headers } from 'next/headers';
 import type { Metadata } from 'next';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { Inter } from 'next/font/google';
@@ -11,6 +12,7 @@ import { envMetadata } from '@/utils/environment';
 import { ApolloWrapper } from '@/components/providers/ApolloWrapper';
 import './globals.css';
 import { Logo } from '@/components/Logo';
+import { PreferredLocaleProvider } from '@/components/providers/PreferredLocaleProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -31,6 +33,9 @@ type Props = {
 
 export default async function RootLayout({ children }: Props) {
   const session = await auth();
+  const headersList = headers();
+  const preferredLanguage =
+    headersList.get('accept-language')?.split(',')[0]?.split(';')[0] || 'en';
 
   return (
     <html lang="en">
@@ -43,31 +48,33 @@ export default async function RootLayout({ children }: Props) {
           flexDirection: 'column',
         }}
       >
-        <AuthProvider session={session}>
-          <ApolloWrapper>
-            <AppRouterCacheProvider>
-              <ThemeProvider>
-                <AppBar />
-                <Box component="main" sx={{ my: 4 }}>
-                  {children}
-                </Box>
-                <Box
-                  component="footer"
-                  sx={{
-                    backgroundColor: 'background.dark',
-                    color: 'primary.contrastText',
-                    py: 4,
-                    mt: 'auto',
-                  }}
-                >
-                  <Container>
-                    <Logo variant="light" size="lg" />
-                  </Container>
-                </Box>
-              </ThemeProvider>
-            </AppRouterCacheProvider>
-          </ApolloWrapper>
-        </AuthProvider>
+        <PreferredLocaleProvider locale={preferredLanguage}>
+          <AuthProvider session={session}>
+            <ApolloWrapper>
+              <AppRouterCacheProvider>
+                <ThemeProvider>
+                  <AppBar />
+                  <Box component="main" sx={{ my: 4 }}>
+                    {children}
+                  </Box>
+                  <Box
+                    component="footer"
+                    sx={{
+                      backgroundColor: 'background.dark',
+                      color: 'primary.contrastText',
+                      py: 4,
+                      mt: 'auto',
+                    }}
+                  >
+                    <Container>
+                      <Logo variant="light" size="lg" />
+                    </Container>
+                  </Box>
+                </ThemeProvider>
+              </AppRouterCacheProvider>
+            </ApolloWrapper>
+          </AuthProvider>
+        </PreferredLocaleProvider>
       </Box>
     </html>
   );

--- a/components/NumberInput.tsx
+++ b/components/NumberInput.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
 } from '@mui/material';
+import { usePreferredLocale } from './providers/PreferredLocaleProvider';
 
 export type NumberInputProps = Omit<
   TextFieldProps,
@@ -32,10 +33,34 @@ export const DEFAULT_NUMBER_PROPS: NumericFormatProps = {
   allowedDecimalSeparators: [',', '.'],
 };
 
+function getSeparator(
+  defaultSeparator: string,
+  sampleNumber: number,
+  partType: keyof Intl.NumberFormatPartTypeRegistry,
+  locale?: string
+) {
+  const formatter = new Intl.NumberFormat(locale);
+
+  return (
+    formatter.formatToParts(sampleNumber).find((part) => part.type === partType)
+      ?.value ?? defaultSeparator
+  );
+}
+
+function getDecimalSeparator(locale?: string) {
+  return getSeparator('.', 1.1, 'decimal', locale);
+}
+
+function getThousandsSeparator(locale?: string) {
+  return getSeparator(' ', 1000, 'group', locale);
+}
+
 export const NumberFormatInput = forwardRef<
   typeof NumericFormat<NumericFormatProps>,
   NumericFormatProps
 >(function NumberFormatInput({ onValueChange, isAllowed, max, ...rest }, ref) {
+  const preferredLocale = usePreferredLocale();
+
   function isAllowedAndBelowMax(values: NumberFormatValues) {
     const { floatValue } = values;
     const belowMax =
@@ -51,6 +76,8 @@ export const NumberFormatInput = forwardRef<
       getInputRef={ref}
       onValueChange={onValueChange}
       isAllowed={isAllowedAndBelowMax}
+      decimalSeparator={getDecimalSeparator(preferredLocale)}
+      thousandSeparator={getThousandsSeparator(preferredLocale)}
     />
   );
 });

--- a/components/providers/PreferredLocaleProvider.tsx
+++ b/components/providers/PreferredLocaleProvider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ReactNode, createContext, useContext } from 'react';
+
+const PreferredLocaleContext = createContext('en');
+
+type Props = {
+  children: ReactNode;
+  locale: string;
+};
+
+export const usePreferredLocale = () => useContext(PreferredLocaleContext);
+
+export function PreferredLocaleProvider({ children, locale }: Props) {
+  return (
+    <PreferredLocaleContext.Provider value={locale}>
+      {children}
+    </PreferredLocaleContext.Provider>
+  );
+}


### PR DESCRIPTION
Ensures number inputs in the data editor follow the user's system locale.

- Get the user's preferred locale from their http header and pass this as context to all components (allows us to use the same language code server side and client side)
- Calculate the thousands and decimal separators based on locale and pass these to the number input field