### PR TITLE
Override some unit names and wrap labels at slashes

### DIFF
--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -35,6 +35,7 @@ import {
   getDecimalPrecisionByUnit,
   getMeasureValue,
   getUnitName,
+  isYearMeasure,
   Section,
 } from '@/utils/measures';
 import {
@@ -150,6 +151,12 @@ function CustomEditComponent({
     size: 'small',
   };
 
+  const yearInputProps = {
+    thousandSeparator: false,
+    maxLength: 4,
+    allowNegative: false,
+  };
+
   if (colDef.type === 'number') {
     return (
       <NumberInput
@@ -160,6 +167,7 @@ function CustomEditComponent({
         inputProps={{
           'aria-label': `${row.label} ${field}`,
           decimalScale: getDecimalPrecisionByUnit(row.unit.long),
+          ...(isYearMeasure(row.label, row.unit.long) ? yearInputProps : {}),
         }}
       />
     );
@@ -170,6 +178,8 @@ function CustomEditComponent({
       {...commonProps}
       onChange={handleValueChange}
       fullWidth
+      multiline
+      maxRows={6}
       value={value || ''}
       inputProps={{
         style: { fontSize: '0.9em' },
@@ -318,6 +328,10 @@ const GRID_COL_DEFS: GridColDef[] = [
     flex: 1,
     valueFormatter: (value: number, row: MeasureRow) => {
       const precision = getDecimalPrecisionByUnit(row.unit.long);
+
+      if (isYearMeasure(row.label, row.unit.long)) {
+        return value;
+      }
 
       return typeof value === 'number'
         ? value.toLocaleString(undefined, { maximumFractionDigits: precision })

--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -34,6 +34,7 @@ import { useDataCollectionStore } from '@/store/data-collection';
 import {
   getDecimalPrecisionByUnit,
   getMeasureValue,
+  getUnitName,
   Section,
 } from '@/utils/measures';
 import {
@@ -304,7 +305,7 @@ const GRID_COL_DEFS: GridColDef[] = [
     valueFormatter: (value: UnitType) => value.long,
     renderCell: (params: GridRenderCellParams<Row>) => (
       <Typography sx={{ my: 1 }} variant={'caption'}>
-        {params.value.long}
+        {getUnitName(params.value.long)}
       </Typography>
     ),
   },

--- a/components/NumberInput.tsx
+++ b/components/NumberInput.tsx
@@ -29,7 +29,6 @@ export type NumberInputProps = Omit<
 export const DEFAULT_NUMBER_PROPS: NumericFormatProps = {
   allowNegative: true,
   allowLeadingZeros: false,
-  thousandSeparator: true,
   allowedDecimalSeparators: [',', '.'],
 };
 
@@ -72,12 +71,12 @@ export const NumberFormatInput = forwardRef<
   return (
     <NumericFormat
       {...DEFAULT_NUMBER_PROPS}
-      {...rest}
       getInputRef={ref}
       onValueChange={onValueChange}
       isAllowed={isAllowedAndBelowMax}
       decimalSeparator={getDecimalSeparator(preferredLocale)}
       thousandSeparator={getThousandsSeparator(preferredLocale)}
+      {...rest}
     />
   );
 });

--- a/constants/units.ts
+++ b/constants/units.ts
@@ -20,3 +20,14 @@ export const DECIMAL_PRECISION_BY_UNIT = {
   'kt/year': 2,
   pcs: 0,
 };
+
+/**
+ * Temporarily override some unit labels that have no backend human readable string
+ */
+export const UNIT_LABELS = {
+  thousand_square_meters: 'thousand square meters',
+  'gigawatt_hour/year': 'gigawatt hour/year',
+  'EUR/megawatt_hour': 'EUR/megawatt hour',
+  // Note: This is a backend bug which needs hotfixing, this can be removed when the "Average passengers per bus" unit is fixed.
+  'pkm/vkm': 'passenger/vehicle',
+};

--- a/constants/units.ts
+++ b/constants/units.ts
@@ -1,6 +1,6 @@
 export const DECIMAL_PRECISION_BY_UNIT = {
   capita: 0,
-  'percent/year': 0,
+  'percent/year': 2,
   'kilometer²': 0,
   'Mpkm/year': 0,
   'passenger/vehicle': 0,
@@ -19,6 +19,7 @@ export const DECIMAL_PRECISION_BY_UNIT = {
   'EUR/kilowatt hour': 2,
   'kt/year': 2,
   pcs: 0,
+  '': 0, // Years have no unit (empty string)
 };
 
 /**

--- a/utils/measures.tsx
+++ b/utils/measures.tsx
@@ -4,7 +4,8 @@ import {
   MeasureTemplateFragmentFragment,
 } from '@/types/__generated__/graphql';
 import { createFilterByTypename } from './filter';
-import { DECIMAL_PRECISION_BY_UNIT } from '@/constants/decimal-precision-by-unit';
+import { DECIMAL_PRECISION_BY_UNIT, UNIT_LABELS } from '@/constants/units';
+import { ReactNode } from 'react';
 
 export type MeasureTemplates = NonNullable<
   MainSectionMeasuresFragment['descendants'][0]['measureTemplates']
@@ -137,5 +138,29 @@ export function getDecimalPrecisionByUnit(unit: string): number | undefined {
   return (
     DECIMAL_PRECISION_BY_UNIT[unit as keyof typeof DECIMAL_PRECISION_BY_UNIT] ??
     undefined
+  );
+}
+
+export function getUnitName(unit: string): ReactNode {
+  const unitLabel = UNIT_LABELS[unit as keyof typeof UNIT_LABELS] ?? unit;
+
+  if (!unitLabel.includes('/')) {
+    return unitLabel;
+  }
+
+  // Ensure units are wrapped at slashes to avoid cell overflow
+  return (
+    <>
+      {unitLabel.split('/').map((part, i, parts) => (
+        <>
+          {part}
+          {i < parts.length - 1 && (
+            <>
+              <wbr />/
+            </>
+          )}
+        </>
+      ))}
+    </>
   );
 }

--- a/utils/measures.tsx
+++ b/utils/measures.tsx
@@ -164,3 +164,15 @@ export function getUnitName(unit: string): ReactNode {
     </>
   );
 }
+
+/**
+ * Albeit hacky, year measures require slightly different formatting and can be
+ * distinguished as the unit is empty and the measure label contains the word "year"
+ */
+export function isYearMeasure(measureLabel: string, unit: string) {
+  if (unit === '' && measureLabel.toLowerCase().includes('year')) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This will be moved to the backend in time. Hotfixing this on the frontend for now until the core data import process is finalised.