### PR TITLE
Show error message on measure mutation failure and fix issue with stale measure values

### DIFF
--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -170,14 +170,20 @@ function CustomEditComponent({
   const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
 
-    apiRef.current.setEditCellValue({ id, field, value: newValue });
-  };
-
-  function handleNumberValueChange(value: NumberFormatValues) {
     apiRef.current.setEditCellValue({
       id,
       field,
+      value: newValue,
+      debounceMs: 400,
+    });
+  };
+
+  async function handleNumberValueChange(value: NumberFormatValues) {
+    await apiRef.current.setEditCellValue({
+      id,
+      field,
       value: value.floatValue ?? '',
+      debounceMs: 400,
     });
   }
 

--- a/components/SnackbarProvider.tsx
+++ b/components/SnackbarProvider.tsx
@@ -13,10 +13,11 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { Alert, AlertProps, Snackbar } from '@mui/material';
+import { Alert, AlertProps, AlertTitle, Snackbar } from '@mui/material';
 
 type Notification = {
   message: string;
+  extraDetails?: string;
   severity: AlertProps['severity'];
 };
 
@@ -40,12 +41,7 @@ export function SnackbarProvider({ children }: Props) {
   const [notification, setNotification] = useState<Notification | null>(null);
 
   return (
-    <SnackbarContext.Provider
-      value={{
-        notification,
-        setNotification: (notification) => setNotification(notification),
-      }}
-    >
+    <SnackbarContext.Provider value={{ notification, setNotification }}>
       <SnackbarWrapper />
       {children}
     </SnackbarContext.Provider>
@@ -84,7 +80,14 @@ export function SnackbarWrapper() {
         variant="filled"
         sx={{ width: '100%' }}
       >
-        {notification?.message}
+        {notification?.extraDetails ? (
+          <>
+            <AlertTitle>{notification.message}</AlertTitle>
+            {notification.extraDetails}
+          </>
+        ) : (
+          notification?.message
+        )}
       </Alert>
     </Snackbar>
   );


### PR DESCRIPTION
1. Improve the visibility of measure mutation errors

https://github.com/user-attachments/assets/09489d3b-123e-4915-ad8d-3b520ec2b6a5

2. Occasionally it seems MUI Grid's `processRowUpdate` is called before the async `setEditCellValue` resolves. This means the `newRow` parameter of `processRowUpdate` is stale and contains the old value. Adding a debounce (via `debounceMs`) seems to fix the issue... but it's hard to test due to the sporadic nature of the error. I expect it's some kind of race condition in the MUI code.