### PR TITLE
Fix wild decimals on a year

### DIFF
--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -483,7 +483,7 @@ const GRID_COL_DEFS: GridColDef[] = [
       const precision = getDecimalPrecisionByUnit(row.unit.long);
 
       if (isYearMeasure(row.label, row.unit.long)) {
-        return value;
+        return Math.round(value);
       }
 
       return typeof value === 'number'


### PR DESCRIPTION
The model returns fallback values of years with fractions, always round years to a whole number.