### PR TITLE
Add view-only mode

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -29,6 +29,7 @@ import type {
 import Loading, { LoadingCard } from '../loading';
 import IntroSection from '@/components/IntroSection';
 import { benefits } from '@/constants/intro-content';
+import { usePermissions } from '@/hooks/use-user-profile';
 
 function CompletionScoreCardWrapper({ instance }: { instance: string }) {
   const { data, error, loading } = useQuery<
@@ -68,6 +69,8 @@ function DataCollectionContent({ instance }: { instance: string }) {
     variables: { frameworkConfigId: instance },
   });
 
+  const permissions = usePermissions();
+
   if (loading) {
     return <LoadingCard />;
   }
@@ -92,7 +95,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
           <Typography gutterBottom variant="h3" component="h2">
             Data collection center
           </Typography>
-          {!!data.framework && (
+          {!!data.framework && permissions.canEdit && (
             <Stack direction="row" spacing={2}>
               <ImportExportActions measureTemplates={data.framework} />
             </Stack>

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -95,7 +95,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
           <Typography gutterBottom variant="h3" component="h2">
             Data collection center
           </Typography>
-          {!!data.framework && permissions.canEdit && (
+          {!!data.framework && permissions.edit && (
             <Stack direction="row" spacing={2}>
               <ImportExportActions measureTemplates={data.framework} />
             </Stack>

--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -181,10 +181,10 @@ export default function CustomEditComponent({
   const [key, setKey] = useState(0);
 
   useLayoutEffect(() => {
-    if (hasFocus && permissions.canEdit && ref.current) {
+    if (hasFocus && permissions.edit && ref.current) {
       ref.current.focus();
     }
-  }, [hasFocus, permissions.canEdit]);
+  }, [hasFocus, permissions.edit]);
 
   async function handleValueChange(event: React.ChangeEvent<HTMLInputElement>) {
     const newValue = event.target.value;
@@ -235,13 +235,11 @@ export default function CustomEditComponent({
         key={key}
         fullWidth
         onKeyDown={handleEscape}
-        onValueChange={
-          permissions.canEdit ? handleNumberValueChange : undefined
-        }
+        onValueChange={permissions.edit ? handleNumberValueChange : undefined}
         defaultValue={
           typeof initialValue.current === 'number' ? initialValue.current : ''
         }
-        disabled={!permissions.canEdit}
+        disabled={!permissions.edit}
         inputProps={{
           'aria-label': `${row.label} ${field}`,
           decimalScale: getDecimalPrecisionByUnit(row.unit.long),
@@ -252,9 +250,9 @@ export default function CustomEditComponent({
       <TextField
         {...commonProps}
         key={key}
-        disabled={!permissions.canEdit}
+        disabled={!permissions.edit}
         onKeyDown={handleEscape}
-        onChange={permissions.canEdit ? handleValueChange : undefined}
+        onChange={permissions.edit ? handleValueChange : undefined}
         fullWidth
         multiline
         maxRows={6}
@@ -266,7 +264,7 @@ export default function CustomEditComponent({
       />
     );
 
-  if (!permissions.canEdit) {
+  if (!permissions.edit) {
     return (
       <Tooltip
         arrow
@@ -830,14 +828,14 @@ function AccordionContentWrapper({
       <AccordionDetails>
         <Box sx={{ height: 400 }}>
           <DataGrid
-            {...(permissions.canEdit ? singleClickEditProps : {})}
+            {...(permissions.edit ? singleClickEditProps : {})}
             loading={loading}
             slots={{ footer: CustomFooter }}
             slotProps={{ footer: { count: rows.length } }}
             sx={DATA_GRID_SX}
             isCellEditable={(params) =>
               !!(
-                permissions.canEdit &&
+                permissions.edit &&
                 params.colDef.editable &&
                 params.row.type !== 'SUM_PERCENT'
               )

--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -58,6 +58,7 @@ import { DataSectionSummary } from './DataSectionSummary';
 import NumberInput, { NumberInputProps } from './NumberInput';
 import { PriorityBadge } from './PriorityBadge';
 import { useSnackbar } from './SnackbarProvider';
+import { usePermissions } from '@/hooks/use-user-profile';
 
 const Accordion = styled((props: AccordionProps) => (
   <MuiAccordion disableGutters elevation={0} square {...props} />
@@ -173,16 +174,17 @@ export default function CustomEditComponent({
   colDef,
   row,
 }: GridRenderEditCellParams & { sx?: SxProps<Theme> }) {
+  const permissions = usePermissions();
   const apiRef = useGridApiContext();
   const ref = useRef<HTMLInputElement | null>(null);
   const initialValue = useRef(value);
   const [key, setKey] = useState(0);
 
   useLayoutEffect(() => {
-    if (hasFocus && ref.current) {
+    if (hasFocus && permissions.canEdit && ref.current) {
       ref.current.focus();
     }
-  }, [hasFocus]);
+  }, [hasFocus, permissions.canEdit]);
 
   async function handleValueChange(event: React.ChangeEvent<HTMLInputElement>) {
     const newValue = event.target.value;
@@ -226,42 +228,57 @@ export default function CustomEditComponent({
     }
   };
 
-  if (colDef.type === 'number') {
-    return (
+  const inputComponent =
+    colDef.type === 'number' ? (
       <NumberInput
         {...commonProps}
         key={key}
         fullWidth
         onKeyDown={handleEscape}
-        onValueChange={handleNumberValueChange}
+        onValueChange={
+          permissions.canEdit ? handleNumberValueChange : undefined
+        }
         defaultValue={
           typeof initialValue.current === 'number' ? initialValue.current : ''
         }
+        disabled={!permissions.canEdit}
         inputProps={{
           'aria-label': `${row.label} ${field}`,
           decimalScale: getDecimalPrecisionByUnit(row.unit.long),
           ...(isYearMeasure(row.label, row.unit.long) ? yearInputProps : {}),
         }}
       />
+    ) : (
+      <TextField
+        {...commonProps}
+        key={key}
+        disabled={!permissions.canEdit}
+        onKeyDown={handleEscape}
+        onChange={permissions.canEdit ? handleValueChange : undefined}
+        fullWidth
+        multiline
+        maxRows={6}
+        defaultValue={initialValue.current || ''}
+        inputProps={{
+          style: { fontSize: '0.9em' },
+          'aria-label': `${row.label} ${field}`,
+        }}
+      />
+    );
+
+  if (!permissions.canEdit) {
+    return (
+      <Tooltip
+        arrow
+        placement="top"
+        title="Request edit access in the NetZeroCities Portal to make changes."
+      >
+        <div>{inputComponent}</div>
+      </Tooltip>
     );
   }
 
-  return (
-    <TextField
-      {...commonProps}
-      key={key}
-      onKeyDown={handleEscape}
-      onChange={handleValueChange}
-      fullWidth
-      multiline
-      maxRows={6}
-      defaultValue={initialValue.current || ''}
-      inputProps={{
-        style: { fontSize: '0.9em' },
-        'aria-label': `${row.label} ${field}`,
-      }}
-    />
-  );
+  return inputComponent;
 }
 
 /**
@@ -706,6 +723,7 @@ function AccordionContentWrapper({
 
   const singleClickEditProps = useSingleClickEdit();
   const setExpanded = useDataCollectionStore((store) => store.setAccordion);
+  const permissions = usePermissions();
 
   const handleChange =
     (panel: number) => (event: React.SyntheticEvent, newExpanded: boolean) => {
@@ -812,13 +830,17 @@ function AccordionContentWrapper({
       <AccordionDetails>
         <Box sx={{ height: 400 }}>
           <DataGrid
-            {...singleClickEditProps}
+            {...(permissions.canEdit ? singleClickEditProps : {})}
             loading={loading}
             slots={{ footer: CustomFooter }}
             slotProps={{ footer: { count: rows.length } }}
             sx={DATA_GRID_SX}
             isCellEditable={(params) =>
-              !!(params.colDef.editable && params.row.type !== 'SUM_PERCENT')
+              !!(
+                permissions.canEdit &&
+                params.colDef.editable &&
+                params.row.type !== 'SUM_PERCENT'
+              )
             }
             getRowClassName={(params) => {
               if (params.row.type === 'SECTION') {

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mui/material';
 import kebabCase from 'lodash/kebabCase';
 
+import { usePermissions } from '@/hooks/use-user-profile';
 import { CREATE_NZC_FRAMEWORK_CONFIG } from '@/queries/framework/create-framework-config';
 import { GET_FRAMEWORK_CONFIGS } from '@/queries/framework/get-framework-config';
 import { useFrameworkInstanceStore } from '@/store/selected-framework-instance';
@@ -100,6 +101,7 @@ function getNavStyles(isActive: boolean): SxProps<Theme> {
 export function InstanceControlBar() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
 
+  const permissions = usePermissions();
   const { data: instanceData, error: instanceError } =
     useSuspenseQuery<GetFrameworkConfigsQuery>(GET_FRAMEWORK_CONFIGS);
 
@@ -242,9 +244,14 @@ export function InstanceControlBar() {
                 instances={instanceConfigs}
               />
             )}
-            <Button onClick={() => setIsAddModalOpen(true)} variant="outlined">
-              Create new plan
-            </Button>
+            {permissions.canEdit && (
+              <Button
+                onClick={() => setIsAddModalOpen(true)}
+                variant="outlined"
+              >
+                Create new plan
+              </Button>
+            )}
           </Stack>
         </Container>
       </Box>

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -244,7 +244,7 @@ export function InstanceControlBar() {
                 instances={instanceConfigs}
               />
             )}
-            {permissions.canEdit && (
+            {permissions.canCreate && (
               <Button
                 onClick={() => setIsAddModalOpen(true)}
                 variant="outlined"

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -244,7 +244,7 @@ export function InstanceControlBar() {
                 instances={instanceConfigs}
               />
             )}
-            {permissions.canCreate && (
+            {permissions.create && (
               <Button
                 onClick={() => setIsAddModalOpen(true)}
                 variant="outlined"

--- a/components/import-export/ImportExportActions.tsx
+++ b/components/import-export/ImportExportActions.tsx
@@ -4,9 +4,9 @@ import { SyntheticEvent, useState } from 'react';
 import { Download, Upload } from 'react-bootstrap-icons';
 import { ExportPlanDialogContent } from './ExportPlanDialogContent';
 import { ImportPlanDialogContent } from './ImportPlanDialogContent';
-import { deploymentType, isDev } from '@/constants/environment';
 import { UploadLegacyDataButton } from '../UploadLegacyDataButton';
 import { useUserProfile } from '@/hooks/use-user-profile';
+import { FRAMEWORK_ADMIN_ROLE } from '@/constants/roles';
 
 type Props = {
   measureTemplates: NonNullable<GetMeasureTemplatesQuery['framework']>;
@@ -43,17 +43,9 @@ export function ImportExportActions({ measureTemplates }: Props) {
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const [activeTab, setActiveTab] = useState<'export' | 'import'>('export');
   const { data: profile, loading: profileLoading } = useUserProfile();
-
-  /**
-   * This is a temporary solution to show the import CSV feature
-   * to certain users in production. This should be removed once
-   * backend user permissions are finalised.
-   *
-   * TODO: Remove this once the backend user permissions are finalised.
-   */
-  const isImportUser =
+  const canImportLegacyCsv =
     !profileLoading &&
-    profile?.me?.email?.endsWith('@redpointsustainability.com');
+    profile?.framework?.userRoles?.includes(FRAMEWORK_ADMIN_ROLE);
 
   function handleClose() {
     setModalOpen(false);
@@ -86,7 +78,7 @@ export function ImportExportActions({ measureTemplates }: Props) {
             <Upload size={24} />
           </Tooltip>
         </IconButton>
-        {(isDev || deploymentType === 'testing' || isImportUser) && (
+        {canImportLegacyCsv && (
           <UploadLegacyDataButton measureTemplates={measureTemplates} />
         )}
       </Stack>

--- a/config/auth.ts
+++ b/config/auth.ts
@@ -202,6 +202,7 @@ const authConfig: NextAuthConfig = {
     },
     async session(params: { session: Session; token: JWT }) {
       const { session, token } = params;
+
       authLogger.info(
         { user: session?.user, runtime: process.env.NEXT_RUNTIME },
         'Session callback'

--- a/constants/roles.ts
+++ b/constants/roles.ts
@@ -1,0 +1,1 @@
+export const FRAMEWORK_ADMIN_ROLE = 'framework-admin';

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -18,6 +18,7 @@ export function useUserProfile() {
 
       framework(identifier: "nzc") {
         id
+        userRoles
         userPermissions {
           change
           creatableRelatedModels

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -15,6 +15,14 @@ export function useUserProfile() {
           orgId
         }
       }
+
+      framework(identifier: "nzc") {
+        id
+        userPermissions {
+          change
+          creatableRelatedModels
+        }
+      }
     }
   `);
 
@@ -23,9 +31,15 @@ export function useUserProfile() {
 
 export function usePermissions() {
   const profileQuery = useUserProfile();
+  const canEdit = !!profileQuery.data?.framework?.userPermissions?.change;
+  const canCreate =
+    !!profileQuery.data?.framework?.userPermissions?.creatableRelatedModels.includes(
+      'FrameworkConfig'
+    );
 
   return {
     isLoading: profileQuery.loading,
-    canEdit: false, // TODO: Implement permission check
+    canEdit,
+    canCreate,
   };
 }

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -20,3 +20,12 @@ export function useUserProfile() {
 
   return queryResult;
 }
+
+export function usePermissions() {
+  const profileQuery = useUserProfile();
+
+  return {
+    isLoading: profileQuery.loading,
+    canEdit: false, // TODO: Implement permission check
+  };
+}

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -109,6 +109,7 @@ export type ActionListPageAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -118,6 +119,7 @@ export type ActionListPageChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -127,6 +129,7 @@ export type ActionListPageDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -136,6 +139,7 @@ export type ActionListPageSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -197,6 +201,11 @@ export type ActionNodeImpactMetricArgs = {
 
 export type ActionNodeMetricArgs = {
   goalId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type ActionNodeMetricDimArgs = {
+  withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 
@@ -373,6 +382,13 @@ export type DeleteFrameworkConfigMutation = {
   ok?: Maybe<Scalars['Boolean']['output']>;
 };
 
+/** An enumeration. */
+export enum DimensionKind {
+  Common = 'COMMON',
+  Node = 'NODE',
+  Scenario = 'SCENARIO'
+}
+
 export type DimensionalFlowType = {
   __typename?: 'DimensionalFlowType';
   id: Scalars['String']['output'];
@@ -524,6 +540,8 @@ export type Framework = {
   name: Scalars['String']['output'];
   section?: Maybe<Section>;
   sections: Array<Section>;
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 
@@ -606,9 +624,13 @@ export type FrameworkConfig = {
   id: Scalars['ID']['output'];
   instance?: Maybe<InstanceType>;
   measures: Array<Measure>;
+  organizationIdentifier?: Maybe<Scalars['String']['output']>;
   organizationName?: Maybe<Scalars['String']['output']>;
+  organizationSlug?: Maybe<Scalars['String']['output']>;
   /** URL for downloading a results file */
   resultsDownloadUrl?: Maybe<Scalars['String']['output']>;
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
   uuid: Scalars['UUID']['output'];
   /** Public URL for instance dashboard */
   viewUrl?: Maybe<Scalars['String']['output']>;
@@ -651,6 +673,7 @@ export type ImageObjectType = {
   aspectRatio: Scalars['Float']['output'];
   collection: CollectionObjectType;
   createdAt: Scalars['DateTime']['output'];
+  description: Scalars['String']['output'];
   file: Scalars['String']['output'];
   fileHash: Scalars['String']['output'];
   fileSize?: Maybe<Scalars['Int']['output']>;
@@ -803,6 +826,7 @@ export type InstanceRootPageAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -812,6 +836,7 @@ export type InstanceRootPageChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -821,6 +846,7 @@ export type InstanceRootPageDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -830,13 +856,16 @@ export type InstanceRootPageSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type InstanceSiteContent = {
+export type InstanceSiteContent = SnippetInterface & {
   __typename?: 'InstanceSiteContent';
+  contentType: Scalars['String']['output'];
   id?: Maybe<Scalars['ID']['output']>;
   introContent?: Maybe<Array<Maybe<StreamFieldInterface>>>;
+  snippetType: Scalars['String']['output'];
 };
 
 export type InstanceType = {
@@ -920,6 +949,8 @@ export type Measure = {
   internalNotes: Scalars['String']['output'];
   measureTemplate: MeasureTemplate;
   unit?: Maybe<UnitType>;
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 /**
@@ -933,6 +964,8 @@ export type MeasureDataPoint = {
   __typename?: 'MeasureDataPoint';
   defaultValue?: Maybe<Scalars['Float']['output']>;
   id: Scalars['ID']['output'];
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
   value?: Maybe<Scalars['Float']['output']>;
   year: Scalars['Int']['output'];
 };
@@ -975,6 +1008,8 @@ export type MeasureTemplate = {
   priority: FrameworksMeasureTemplatePriorityChoices;
   timeSeriesMax?: Maybe<Scalars['Float']['output']>;
   unit: UnitType;
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
   uuid: Scalars['UUID']['output'];
 };
 
@@ -1004,6 +1039,8 @@ export type MeasureTemplateMeasureArgs = {
 export type MeasureTemplateDefaultDataPoint = {
   __typename?: 'MeasureTemplateDefaultDataPoint';
   id: Scalars['ID']['output'];
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
   value: Scalars['Float']['output'];
   year: Scalars['Int']['output'];
 };
@@ -1033,6 +1070,7 @@ export type MetricDimensionType = {
   groups: Array<MetricDimensionCategoryGroupType>;
   helpText?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  kind: DimensionKind;
   label: Scalars['String']['output'];
   originalId?: Maybe<Scalars['ID']['output']>;
 };
@@ -1043,6 +1081,14 @@ export type MetricYearlyGoalType = {
   value: Scalars['Float']['output'];
   year: Scalars['Int']['output'];
 };
+
+/** An enumeration. */
+export enum ModelAction {
+  Add = 'ADD',
+  Change = 'CHANGE',
+  Delete = 'DELETE',
+  View = 'VIEW'
+}
 
 export type Mutations = {
   __typename?: 'Mutations';
@@ -1113,7 +1159,9 @@ export type MutationsSetParameterArgs = {
 export type MutationsUpdateFrameworkConfigArgs = {
   baselineYear?: InputMaybe<Scalars['Int']['input']>;
   id: Scalars['ID']['input'];
+  organizationIdentifier?: InputMaybe<Scalars['String']['input']>;
   organizationName?: InputMaybe<Scalars['String']['input']>;
+  organizationSlug?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1195,6 +1243,11 @@ export type NodeMetricArgs = {
 };
 
 
+export type NodeMetricDimArgs = {
+  withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
 export type NodeUpstreamActionsArgs = {
   decisionLevel?: InputMaybe<DecisionLevel>;
   onlyRoot?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1263,6 +1316,11 @@ export type NodeInterfaceImpactMetricArgs = {
 
 export type NodeInterfaceMetricArgs = {
   goalId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type NodeInterfaceMetricDimArgs = {
+  withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 
@@ -1350,6 +1408,7 @@ export type OutcomePageAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1359,6 +1418,7 @@ export type OutcomePageChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1368,6 +1428,7 @@ export type OutcomePageDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1377,6 +1438,7 @@ export type OutcomePageSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1438,6 +1500,7 @@ export type PageAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1451,6 +1514,7 @@ export type PageChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1464,6 +1528,7 @@ export type PageDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1477,6 +1542,7 @@ export type PageSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1519,6 +1585,7 @@ export type PageInterfaceAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1528,6 +1595,7 @@ export type PageInterfaceChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1537,6 +1605,7 @@ export type PageInterfaceDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1546,6 +1615,7 @@ export type PageInterfaceSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1568,7 +1638,7 @@ export type Query = {
   actionEfficiencyPairs: Array<ActionEfficiencyPairType>;
   actions: Array<ActionNode>;
   activeNormalization?: Maybe<NormalizationType>;
-  activeScenario?: Maybe<ScenarioType>;
+  activeScenario: ScenarioType;
   availableInstances: Array<InstanceBasicConfiguration>;
   availableNormalizations: Array<NormalizationType>;
   framework?: Maybe<Framework>;
@@ -1675,13 +1745,30 @@ export type RichTextBlock = StreamFieldInterface & {
   value: Scalars['String']['output'];
 };
 
+/** An enumeration. */
+export enum ScenarioKind {
+  Baseline = 'BASELINE',
+  Custom = 'CUSTOM',
+  Default = 'DEFAULT',
+  ProgressTracking = 'PROGRESS_TRACKING'
+}
+
 export type ScenarioType = {
   __typename?: 'ScenarioType';
+  actualHistoricalYears?: Maybe<Array<Scalars['Int']['output']>>;
   id?: Maybe<Scalars['ID']['output']>;
-  isActive?: Maybe<Scalars['Boolean']['output']>;
-  isDefault?: Maybe<Scalars['Boolean']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+  isActive: Scalars['Boolean']['output'];
+  isDefault: Scalars['Boolean']['output'];
+  isSelectable: Scalars['Boolean']['output'];
+  kind?: Maybe<ScenarioKind>;
+  name: Scalars['String']['output'];
 };
+
+/** Enum for search operator. */
+export enum SearchOperatorEnum {
+  And = 'AND',
+  Or = 'OR'
+}
 
 /**
  * Represents a section within a framework.
@@ -1701,6 +1788,8 @@ export type Section = {
   name: Scalars['String']['output'];
   parent?: Maybe<Section>;
   path: Scalars['String']['output'];
+  userPermissions?: Maybe<UserPermissions>;
+  userRoles?: Maybe<Array<Scalars['String']['output']>>;
   uuid: Scalars['UUID']['output'];
 };
 
@@ -1751,9 +1840,11 @@ export type SiteObjectTypePageArgs = {
 export type SiteObjectTypePagesArgs = {
   contentType?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1763,10 +1854,13 @@ export type SnippetChooserBlock = StreamFieldInterface & {
   field: Scalars['String']['output'];
   id?: Maybe<Scalars['String']['output']>;
   rawValue: Scalars['String']['output'];
-  snippet?: Maybe<SnippetObjectType>;
+  snippet?: Maybe<SnippetInterface>;
 };
 
-export type SnippetObjectType = InstanceSiteContent;
+export type SnippetInterface = {
+  contentType: Scalars['String']['output'];
+  snippetType: Scalars['String']['output'];
+};
 
 export type StaticBlock = StreamFieldInterface & {
   __typename?: 'StaticBlock';
@@ -1823,6 +1917,7 @@ export type StaticPageAncestorsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1832,6 +1927,7 @@ export type StaticPageChildrenArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1841,6 +1937,7 @@ export type StaticPageDescendantsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1850,6 +1947,7 @@ export type StaticPageSiblingsArgs = {
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
+  searchOperator?: InputMaybe<SearchOperatorEnum>;
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1991,6 +2089,17 @@ export type UserFrameworkRole = {
   roleId?: Maybe<Scalars['String']['output']>;
 };
 
+/** Permissions for a user on a model instance. */
+export type UserPermissions = {
+  __typename?: 'UserPermissions';
+  actions: Array<Maybe<ModelAction>>;
+  change: Scalars['Boolean']['output'];
+  creatableRelatedModels: Array<Maybe<Scalars['String']['output']>>;
+  delete: Scalars['Boolean']['output'];
+  otherPermissions: Array<Maybe<Scalars['String']['output']>>;
+  view: Scalars['Boolean']['output'];
+};
+
 export type UserType = {
   __typename?: 'UserType';
   email: Scalars['String']['output'];
@@ -2036,6 +2145,12 @@ export type ProfileQuery = (
       & { __typename?: 'UserFrameworkRole' }
     )> | null }
     & { __typename?: 'UserType' }
+  ) | null, framework?: (
+    { id: string, userPermissions?: (
+      { change: boolean, creatableRelatedModels: Array<string | null> }
+      & { __typename?: 'UserPermissions' }
+    ) | null }
+    & { __typename?: 'Framework' }
   ) | null }
   & { __typename?: 'Query' }
 );

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -2146,7 +2146,7 @@ export type ProfileQuery = (
     )> | null }
     & { __typename?: 'UserType' }
   ) | null, framework?: (
-    { id: string, userPermissions?: (
+    { id: string, userRoles?: Array<string> | null, userPermissions?: (
       { change: boolean, creatableRelatedModels: Array<string | null> }
       & { __typename?: 'UserPermissions' }
     ) | null }

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -2149,7 +2149,13 @@ export type ProfileQuery = (
     { id: string, userRoles?: Array<string> | null, userPermissions?: (
       { change: boolean, creatableRelatedModels: Array<string | null> }
       & { __typename?: 'UserPermissions' }
-    ) | null }
+    ) | null, configs: Array<(
+      { id: string, userPermissions?: (
+        { view: boolean, change: boolean, delete: boolean, actions: Array<ModelAction | null>, creatableRelatedModels: Array<string | null>, otherPermissions: Array<string | null> }
+        & { __typename?: 'UserPermissions' }
+      ) | null }
+      & { __typename: 'FrameworkConfig' }
+    )> }
     & { __typename?: 'Framework' }
   ) | null }
   & { __typename?: 'Query' }

--- a/types/__generated__/possible_types.json
+++ b/types/__generated__/possible_types.json
@@ -17,7 +17,7 @@
       "StringParameterType",
       "UnknownParameterType"
     ],
-    "SnippetObjectType": [
+    "SnippetInterface": [
       "InstanceSiteContent"
     ],
     "StreamFieldInterface": [


### PR DESCRIPTION
View-only mode displays all plan data, links to download the Climate City Contracts and Paths dashboard, but disables all input fields and hides the import buttons.

⚠️ The backend for this is only available in a WIP deployment, to test locally you'll need to update your `.env.local`:

```
AUTH_CLIENT_ID=<ask me>
AUTH_CLIENT_SECRET=<ask me>
KAUSAL_PUBLIC_AUTH_ISSUER=https://admin.paths-wip.kausal.dev/
KAUSAL_PUBLIC_API_URL=https://api.paths-wip.kausal.dev/v1
```

<img width="831" alt="Screenshot 2024-10-08 at 15 50 39" src="https://github.com/user-attachments/assets/80aa1ef3-9ec8-4811-ad0e-121598bde253">
