### PR TITLE
Fix entry of decimals when the user doesn't enter a leading zero e.g. ".02"

### DIFF
--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -220,7 +220,7 @@ function CustomEditComponent({
         {...commonProps}
         fullWidth
         onValueChange={handleNumberValueChange}
-        value={typeof value === 'number' ? value : ''}
+        defaultValue={typeof value === 'number' ? value : ''}
         inputProps={{
           'aria-label': `${row.label} ${field}`,
           decimalScale: getDecimalPrecisionByUnit(row.unit.long),

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -447,7 +447,7 @@ export function InstanceControlBar() {
                 </FormControl>
 
                 <FormControl required>
-                  <FormLabel id="baseline-select" sx={{ mb: 0.5 }}>
+                  <FormLabel id="climate-select" sx={{ mb: 0.5 }}>
                     <Typography component="span" variant="body2">
                       Is your city warm or cold?
                     </Typography>
@@ -468,7 +468,7 @@ export function InstanceControlBar() {
                 </FormControl>
 
                 <FormControl required>
-                  <FormLabel id="baseline-select" sx={{ mb: 0.5 }}>
+                  <FormLabel id="electricity-select" sx={{ mb: 0.5 }}>
                     <Typography component="span" variant="body2">
                       What's the percentage of renewable plus nuclear energy in
                       your electricity mix?

--- a/components/NumberInput.tsx
+++ b/components/NumberInput.tsx
@@ -15,7 +15,7 @@ export type NumberInputProps = Omit<
   TextFieldProps,
   'type' | 'value' | 'onChange' | 'inputProps' | 'InputProps' | 'variant'
 > & {
-  value: number | undefined | ''; // An empty string can be used to clear the input
+  value?: number | undefined | ''; // An empty string can be used to clear the input
   inputProps?: {
     /** Maximum value, higher numbers will be prevented upon typing */
     max?: number;


### PR DESCRIPTION
Due to the previously controlled input, the value was parsed while the user typed and ".0" became "0". Switching to an uncontrolled input resolves this.