### PR TITLE
Add navigation and refactor the main nav bar component

### DIFF
--- a/app/(home)/additional-data/page.tsx
+++ b/app/(home)/additional-data/page.tsx
@@ -12,9 +12,24 @@ import { QuestionCircle } from 'react-bootstrap-icons';
 import { useFrameworkInstanceStore } from '@/store/selected-framework-instance';
 import Tip from '@/components/Tip';
 import { AdditionalDatasheetEditor } from '@/components/AdditionalDatasheetEditor';
+import { redirect } from 'next/navigation';
+import { captureException } from '@sentry/nextjs';
+import { isHistoricalDataAvailable } from '@/utils/historical-data';
 
 export default function AdditionalDataPage() {
   const baselineYear = useFrameworkInstanceStore((state) => state.baselineYear);
+
+  if (baselineYear == null) {
+    captureException(
+      'No baseline year found when accessing additional data page'
+    );
+
+    return redirect('/');
+  }
+
+  if (!isHistoricalDataAvailable(baselineYear)) {
+    return redirect('/');
+  }
 
   return (
     <Fade in>

--- a/app/(home)/additional-data/page.tsx
+++ b/app/(home)/additional-data/page.tsx
@@ -12,23 +12,29 @@ import { QuestionCircle } from 'react-bootstrap-icons';
 import { useFrameworkInstanceStore } from '@/store/selected-framework-instance';
 import Tip from '@/components/Tip';
 import { AdditionalDatasheetEditor } from '@/components/AdditionalDatasheetEditor';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { captureException } from '@sentry/nextjs';
-import { isHistoricalDataAvailable } from '@/utils/historical-data';
+import { areHistoricalYearsAvailable } from '@/utils/historical-data';
 
 export default function AdditionalDataPage() {
+  const router = useRouter();
   const baselineYear = useFrameworkInstanceStore((state) => state.baselineYear);
 
+  // Redirect to home if the baseline year is not set or if the historical data is not available
   if (baselineYear == null) {
     captureException(
       'No baseline year found when accessing additional data page'
     );
 
-    return redirect('/');
+    router.replace('/');
+
+    return null;
   }
 
-  if (!isHistoricalDataAvailable(baselineYear)) {
-    return redirect('/');
+  if (!areHistoricalYearsAvailable(baselineYear)) {
+    router.replace('/');
+
+    return null;
   }
 
   return (

--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { Box } from '@mui/material';
 
 import { InstanceControlBar } from '@/components/InstanceControlBar';
-import { redirect, RedirectType } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import Loading from '../loading';
 
@@ -15,6 +15,7 @@ type Props = {
 
 export default function HomeLayout({ children }: Props) {
   const { status } = useSession();
+  const router = useRouter();
   const [isAuthenticated, setIsAuthenticated] = useState(
     status === 'authenticated'
   );
@@ -32,7 +33,7 @@ export default function HomeLayout({ children }: Props) {
   }
 
   if (status === 'unauthenticated') {
-    return redirect('/welcome', RedirectType.replace);
+    return router.replace('/welcome');
   }
 
   return (

--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -1,14 +1,40 @@
-import { ReactNode } from 'react';
+'use client';
+
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { Box } from '@mui/material';
 
 import { InstanceControlBar } from '@/components/InstanceControlBar';
+import { redirect, RedirectType } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import Loading from '../loading';
 
 type Props = {
   children: ReactNode;
 };
 
-export default async function HomeLayout({ children }: Props) {
+export default function HomeLayout({ children }: Props) {
+  const { status } = useSession();
+  const [isAuthenticated, setIsAuthenticated] = useState(
+    status === 'authenticated'
+  );
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      setIsAuthenticated(true);
+    } else if (status === 'unauthenticated') {
+      setIsAuthenticated(false);
+    }
+  }, [status]);
+
+  if (!isAuthenticated && status === 'loading') {
+    return <Loading />;
+  }
+
+  if (status === 'unauthenticated') {
+    return redirect('/welcome', RedirectType.replace);
+  }
+
   return (
     <>
       <Box sx={{ mt: -4 }}>

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -110,7 +110,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
   );
 }
 
-function DashboardContent() {
+export default function DashboardContent() {
   const {
     data: selectedInstanceId,
     isDataInitialized: isInstanceStoreInitialized,
@@ -236,35 +236,4 @@ function DashboardContent() {
       </Container>
     </Fade>
   );
-}
-
-export default function Dashboard() {
-  const { status } = useSession();
-  const [isAuthenticated, setIsAuthenticated] = useState(
-    status === 'authenticated'
-  );
-
-  useEffect(() => {
-    if (status === 'authenticated') {
-      setIsAuthenticated(true);
-    } else if (status === 'unauthenticated') {
-      setIsAuthenticated(false);
-    }
-  }, [status]);
-
-  const dashboard = useMemo(() => {
-    if (isAuthenticated) {
-      return <DashboardContent />;
-    }
-  }, [isAuthenticated]);
-
-  if (!isAuthenticated && status === 'loading') {
-    return <Loading />;
-  }
-
-  if (status === 'unauthenticated') {
-    return redirect('/welcome', RedirectType.replace);
-  }
-
-  return dashboard;
 }

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { redirect, RedirectType } from 'next/navigation';
-
 import { useQuery, useSuspenseQuery } from '@apollo/client';
 import {
   Button,
@@ -15,7 +12,6 @@ import {
   Typography,
 } from '@mui/material';
 import * as Sentry from '@sentry/nextjs';
-import { useSession } from 'next-auth/react';
 import { BoxArrowUpRight, Download } from 'react-bootstrap-icons';
 
 import CompletionScoreCard from '@/components/CompletionScoreCard';

--- a/components/AddPlanDialog.tsx
+++ b/components/AddPlanDialog.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ExclamationTriangle, FileEarmarkPlus, X } from 'react-bootstrap-icons';
+
+import NumberInput from './NumberInput';
+
+type ClimateOption = 'warm' | 'cold';
+type RenewableMixOption = 'low' | 'high';
+type Option<T> = { label: string; value: T };
+
+export type NewPlanData = {
+  planName: string;
+  baselineYear: number | '';
+  population: number | '';
+  climate: ClimateOption | null;
+  renewableElectricityMix: RenewableMixOption | null;
+};
+
+const BASELINE_OPTIONS = [2018, 2019, 2020, 2021, 2022, 2023];
+const PANDEMIC_YEARS = [2020, 2021];
+
+const CLIMATE_OPTIONS: Option<ClimateOption>[] = [
+  { label: 'Warm (Above 12°C yearly average)', value: 'warm' },
+  { label: 'Cold (Below 12°C yearly average)', value: 'cold' },
+];
+
+const RENEWABLE_ELECTRICITY_OPTIONS: Option<RenewableMixOption>[] = [
+  { label: 'High (50-100% renewable & nuclear)', value: 'high' },
+  { label: 'Low (0-50% renewable & nuclear)', value: 'low' },
+];
+
+const INITIAL_DATA: NewPlanData = {
+  planName: '',
+  baselineYear: '',
+  population: '',
+  climate: null,
+  renewableElectricityMix: null,
+};
+
+function getErrorMessage(error: Error) {
+  // Temporary hack to override non-user friendly error message
+  if (
+    error.message.startsWith('Instance with identifier') &&
+    error.message.endsWith('already exists')
+  ) {
+    return 'A city plan with this name already exists. Please choose a different name.';
+  }
+  return `Error creating plan: ${error.message}`;
+}
+
+function isValid(data: NewPlanData, onlyStepOne = false): boolean {
+  const validFirstStep = !!(data.planName && data.baselineYear);
+
+  if (onlyStepOne) {
+    return validFirstStep;
+  }
+
+  return !!(
+    validFirstStep &&
+    data.population &&
+    data.renewableElectricityMix &&
+    data.climate
+  );
+}
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: NewPlanData) => void;
+  loading: boolean;
+  error?: Error;
+};
+
+export function AddPlanDialog({
+  open,
+  onClose,
+  onSubmit,
+  loading,
+  error,
+}: Props) {
+  const [step, setStep] = useState(0);
+  const [data, setData] = useState<NewPlanData>(INITIAL_DATA);
+
+  function resetForm() {
+    setStep(0);
+    setData(INITIAL_DATA);
+  }
+
+  function handleClose() {
+    resetForm();
+    onClose();
+  }
+
+  function handleChange(
+    field: keyof NewPlanData,
+    value: NewPlanData[typeof field]
+  ) {
+    setData((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (isValid(data)) {
+      onSubmit(data);
+    }
+  }
+
+  useEffect(() => {
+    if (!open) {
+      resetForm();
+    }
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          spacing={1}
+        >
+          <Box sx={{ fontSize: 0 }}>
+            <FileEarmarkPlus size={24} />
+          </Box>
+          <Box component="span" flex="1">
+            <div>Create new plan</div>
+          </Box>
+          <IconButton aria-label="close" onClick={handleClose}>
+            <X size={24} />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <form noValidate autoComplete="off" onSubmit={handleSubmit}>
+        <DialogContent sx={{ px: 3, pt: 0 }}>
+          <Box sx={{ mb: 4 }}>
+            {step === 0 ? (
+              <Typography variant="body1" color="text.secondary">
+                Create a new climate action plan to track and manage your city's
+                emissions data. Create multiple plans to envision various
+                scenarios.
+              </Typography>
+            ) : (
+              <Typography variant="body1" color="text.secondary">
+                {data.planName} ({data.baselineYear})
+              </Typography>
+            )}
+          </Box>
+
+          {step === 0 ? (
+            <Stack spacing={2}>
+              <TextField
+                required
+                label="Plan or city name"
+                value={data.planName}
+                onChange={(e) => handleChange('planName', e.target.value)}
+              />
+              <FormControl required>
+                <InputLabel id="baseline-select">Baseline year</InputLabel>
+                <Select
+                  label="Baseline year"
+                  labelId="baseline-select"
+                  id="baseline-select-component"
+                  renderValue={(value) => value}
+                  value={data.baselineYear}
+                  onChange={(e) =>
+                    handleChange('baselineYear', Number(e.target.value))
+                  }
+                >
+                  {BASELINE_OPTIONS.map((year) => (
+                    <MenuItem key={year} value={year}>
+                      <Stack spacing={0.5}>
+                        <Typography>{year}</Typography>
+                        {PANDEMIC_YEARS.includes(year) && (
+                          <Stack
+                            sx={{ color: 'text.secondary' }}
+                            direction="row"
+                            spacing={0.5}
+                            justifyContent="center"
+                          >
+                            <Box sx={{ color: 'warning.main' }}>
+                              <ExclamationTriangle size={16} />
+                            </Box>
+                            <Typography variant="caption">
+                              COVID-19 may have skewed data for this year
+                            </Typography>
+                          </Stack>
+                        )}
+                      </Stack>
+                    </MenuItem>
+                  ))}
+                </Select>
+
+                {data.baselineYear &&
+                PANDEMIC_YEARS.includes(data.baselineYear) ? (
+                  <FormHelperText
+                    component={Stack}
+                    sx={{ color: 'warning.dark', pt: 1 }}
+                    direction="row"
+                    spacing={1}
+                    justifyContent="center"
+                  >
+                    <Box>
+                      <ExclamationTriangle size={18} />
+                    </Box>
+                    <Typography variant="caption">
+                      COVID-19 may have skewed data for this year. Consider
+                      another baseline year for more typical results.
+                    </Typography>
+                  </FormHelperText>
+                ) : (
+                  <FormHelperText>
+                    The baseline year is the reference point for measuring
+                    future emission reductions. You must provide your city's
+                    operational and statistical data for this specific year.
+                  </FormHelperText>
+                )}
+              </FormControl>
+            </Stack>
+          ) : (
+            <Stack spacing={2}>
+              <FormControl required>
+                <FormLabel id="population-input" sx={{ mb: 0.5 }}>
+                  <Typography component="span" variant="body2">
+                    What's your city's population?
+                  </Typography>
+                </FormLabel>
+                <NumberInput
+                  aria-labelledby="population-input"
+                  inputProps={{
+                    allowNegative: false,
+                    min: 0,
+                    max: 50000000,
+                  }}
+                  value={data.population}
+                  onValueChange={(values) =>
+                    handleChange('population', values.floatValue ?? '')
+                  }
+                />
+              </FormControl>
+
+              <FormControl required>
+                <FormLabel id="climate-select" sx={{ mb: 0.5 }}>
+                  <Typography component="span" variant="body2">
+                    Is your city warm or cold?
+                  </Typography>
+                </FormLabel>
+                <Select
+                  hiddenLabel
+                  labelId="climate-select"
+                  id="climate-select-component"
+                  value={data.climate ?? ''}
+                  onChange={(e) => handleChange('climate', e.target.value)}
+                >
+                  {CLIMATE_OPTIONS.map(({ value, label }) => (
+                    <MenuItem key={value} value={value}>
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl required>
+                <FormLabel id="electricity-select" sx={{ mb: 0.5 }}>
+                  <Typography component="span" variant="body2">
+                    What's the percentage of renewable plus nuclear energy in
+                    your electricity mix?
+                  </Typography>
+                </FormLabel>
+                <Select
+                  hiddenLabel
+                  labelId="electricity-select"
+                  id="electricity-select-component"
+                  value={data.renewableElectricityMix ?? ''}
+                  onChange={(e) =>
+                    handleChange('renewableElectricityMix', e.target.value)
+                  }
+                >
+                  {RENEWABLE_ELECTRICITY_OPTIONS.map(({ value, label }) => (
+                    <MenuItem key={value} value={value}>
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+          )}
+
+          {error && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              <AlertTitle>{getErrorMessage(error)}</AlertTitle>
+            </Alert>
+          )}
+        </DialogContent>
+
+        <DialogActions
+          sx={{
+            justifyContent: 'flex-end',
+            px: 3,
+            pb: 3,
+          }}
+        >
+          {step === 0 ? (
+            <>
+              <Button variant="text" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                onClick={() => setStep(1)}
+                disabled={!isValid(data, true)}
+              >
+                Next
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="text" onClick={() => setStep(0)}>
+                Previous
+              </Button>
+              <Button
+                variant="contained"
+                type="submit"
+                disabled={loading || !isValid(data)}
+                endIcon={
+                  loading ? (
+                    <CircularProgress color="inherit" size={20} />
+                  ) : null
+                }
+              >
+                {loading ? 'Adding...' : 'Add plan'}
+              </Button>
+            </>
+          )}
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -13,17 +13,25 @@ import {
   Theme,
   Toolbar,
   Typography,
+  Divider,
+  ListItemIcon,
+  ListItemText,
 } from '@mui/material';
 import { Session } from 'next-auth';
 import { signIn, useSession } from 'next-auth/react';
-import { PersonCircle, QuestionCircle } from 'react-bootstrap-icons';
+import {
+  BoxArrowRight,
+  PersonCircle,
+  QuestionCircle,
+} from 'react-bootstrap-icons';
+import { useRouter } from 'next/navigation';
+import startCase from 'lodash/startCase';
 
 import { useUserProfile } from '@/hooks/use-user-profile';
 import { getUserDisplay } from '@/utils/session';
 import { Logo } from './Logo';
 import SupportModal from './SupportModal';
 import { handleBackendSignOut } from '@/app/actions';
-import { useRouter } from 'next/navigation';
 
 const APP_BAR_STYLES: SxProps<Theme> = {
   backgroundColor: 'common.white',
@@ -59,9 +67,13 @@ export function AppBar() {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [supportModalOpen, setSupportModalOpen] = useState(false);
   const session = useSession();
+  const { data: profile, loading: loadingProfile } = useUserProfile();
   const router = useRouter();
 
   const isAuthenticated = session.status === 'authenticated';
+
+  const orgSlug = profile?.me?.frameworkRoles?.[0]?.orgSlug;
+  const email = profile?.me?.email;
 
   const handleOpenAuthMenu = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
@@ -147,7 +159,31 @@ export function AppBar() {
               open={!!menuAnchorEl}
               onClose={handleCloseAuthMenu}
             >
-              <MenuItem onClick={handleSignOut}>Sign out</MenuItem>
+              <MenuItem onClick={handleSignOut}>
+                <ListItemIcon sx={{ minWidth: '0 !important', mr: 1 }}>
+                  <BoxArrowRight size={18} />
+                </ListItemIcon>
+                <ListItemText>Sign out</ListItemText>
+              </MenuItem>
+              <Divider />
+              <MenuItem disabled>
+                {loadingProfile ? (
+                  <Skeleton width={100} height={24} />
+                ) : (
+                  <Typography variant="body2">{email}</Typography>
+                )}
+              </MenuItem>
+              <MenuItem disabled>
+                {loadingProfile ? (
+                  <Skeleton width={100} height={24} />
+                ) : (
+                  orgSlug && (
+                    <Typography variant="body2">
+                      {startCase(orgSlug)}
+                    </Typography>
+                  )
+                )}
+              </MenuItem>
             </Menu>
           </div>
         </Toolbar>

--- a/components/Tip.tsx
+++ b/components/Tip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Typography,
   Button,
@@ -18,39 +18,40 @@ interface TipProps {
   storageKey: string;
 }
 
+function getStoredTipState(storageKey: string) {
+  try {
+    return localStorage.getItem(storageKey);
+  } catch {
+    return 'open';
+  }
+}
+
+function storeTipState(storageKey: string, state: 'open' | 'closed') {
+  try {
+    localStorage.setItem(storageKey, state);
+  } catch {}
+}
+
 export const Tip = ({ title, text, storageKey }: TipProps) => {
   const theme = useTheme();
-  const [isTextVisible, setIsTextVisible] = useState(true);
-  const [isTipOpen, setIsTipOpen] = useState(true);
-
-  useEffect(() => {
-    try {
-      const savedTipState = localStorage.getItem(storageKey);
-      if (savedTipState === 'closed') {
-        setIsTextVisible(false);
-      }
-    } catch {}
-  }, [storageKey]);
+  const [isTipOpen, setIsTipOpen] = useState(
+    () => getStoredTipState(storageKey) === 'open'
+  );
 
   const handleDismiss = () => {
-    setIsTextVisible(false);
     setIsTipOpen(false);
-    try {
-      localStorage.setItem(storageKey, 'closed');
-    } catch {}
+    storeTipState(storageKey, 'closed');
   };
 
   const handleToggleTip = () => {
-    const newTipState = !isTextVisible;
-    setIsTextVisible(newTipState);
-    try {
-      localStorage.setItem(storageKey, newTipState ? 'open' : 'closed');
-    } catch {}
+    const newTipState = !isTipOpen;
+    setIsTipOpen(newTipState);
+    storeTipState(storageKey, newTipState ? 'open' : 'closed');
   };
 
   return (
     <Accordion
-      expanded={isTextVisible}
+      expanded={isTipOpen}
       onChange={handleToggleTip}
       sx={{
         marginY: 2,
@@ -77,7 +78,7 @@ export const Tip = ({ title, text, storageKey }: TipProps) => {
           onClick={handleDismiss}
           sx={{ marginTop: 1 }}
         >
-          Dismiss this tip
+          Hide this tip
         </Button>
       </AccordionDetails>
     </Accordion>

--- a/utils/historical-data.ts
+++ b/utils/historical-data.ts
@@ -1,0 +1,4 @@
+// Check if historical data would be available since the given baseline year
+export function areHistoricalYearsAvailable(baselineYear: number) {
+  return baselineYear < new Date().getFullYear() - 1;
+}


### PR DESCRIPTION
This includes a few additional changes/ fixes:
- The `Tip` component was always expanded on first render, leading to an issue where it flashed as open when switching pages even though the tip was stored to local storage as closed 9f1195d65974c716cc74648495f9620e1da4069a
- I moved the additional data page under the `(home)` path so it now also renders the navigation/ plan selector bar
- Moved the plan dialog code to `components/AddPlanDialog.tsx`
- Updated the user menu to include the user's email and city now that it's been replaced by the menu on the plan selector bar
- Added a check on the additional data page to see if there are any years available for additional data (i.e. is the baseline year last year), and redirect to home if not