### PR TITLE
Refactor additional data editor to use labels rather than questions

### DIFF
--- a/components/AdditionalDatasheetEditor.tsx
+++ b/components/AdditionalDatasheetEditor.tsx
@@ -426,7 +426,9 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
       {...(permissions.edit ? singleClickEditProps : {})}
       loading={loading}
       slots={{ footer: CustomFooter }}
-      slotProps={{ footer: { count: rows.length } }}
+      slotProps={{
+        footer: { count: rows.filter((row) => row.type === 'MEASURE').length },
+      }}
       sx={DATA_GRID_SX}
       isCellEditable={(params) =>
         !!(permissions.edit && params.colDef.editable)

--- a/components/AdditionalDatasheetEditor.tsx
+++ b/components/AdditionalDatasheetEditor.tsx
@@ -1,26 +1,22 @@
 'use client';
 
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import {
-  Accordion as MuiAccordion,
-  AccordionDetails as MuiAccordionDetails,
   AccordionSummary as MuiAccordionSummary,
   Box,
   Typography,
-  SxProps,
-  Theme,
-  Skeleton,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
-import {
-  DataGrid,
-  GridColDef,
-  GridRenderCellParams,
-  GridRenderEditCellParams,
-} from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { ChevronDown } from 'react-bootstrap-icons';
-import { getDecimalPrecisionByUnit, isYearMeasure } from '@/utils/measures';
+import {
+  getDecimalPrecisionByUnit,
+  getMeasureValue,
+  getUnitName,
+  isYearMeasure,
+  mapMeasureTemplatesToRows,
+  Section,
+} from '@/utils/measures';
 
 import { GET_MEASURE_TEMPLATES } from '@/queries/get-measure-templates';
 import { UPDATE_MEASURE_DATAPOINT } from '@/queries/update-measure-datapoint';
@@ -28,102 +24,199 @@ import {
   UpdateMeasureDataPointMutation,
   UpdateMeasureDataPointMutationVariables,
   GetMeasureTemplatesQuery,
+  UnitType,
+  MeasureTemplateFragmentFragment,
 } from '@/types/__generated__/graphql';
 import { useFrameworkInstanceStore } from '@/store/selected-framework-instance';
 import { useSnackbar } from './SnackbarProvider';
-import { additionalMeasures } from '@/constants/measure-overrides';
-import CustomEditComponent from './DatasheetEditor';
+import CustomEditComponent, {
+  Accordion,
+  AccordionDetails,
+  DATA_GRID_SX,
+  useSingleClickEdit,
+} from './DatasheetEditor';
 import { CustomFooter } from './DatasheetEditor';
+import { additionalMeasures } from '@/constants/measure-overrides';
+import { usePermissions } from '@/hooks/use-user-profile';
+import { GET_MEASURE_TEMPLATE } from '@/queries/get-measure-template';
+import { LoadingCard } from '@/app/loading';
+import { default as ErrorComponent } from '@/app/error';
+import { captureException } from '@sentry/nextjs';
 
-const Accordion = styled(MuiAccordion)(({ theme }) => ({
-  '&:first-of-type': {
-    borderTopLeftRadius: theme.shape.borderRadius,
-    borderTopRightRadius: theme.shape.borderRadius,
-  },
-  '&:last-of-type': {
-    borderBottomLeftRadius: theme.shape.borderRadius,
-    borderBottomRightRadius: theme.shape.borderRadius,
-  },
-  border: `1px solid ${theme.palette.divider}`,
-  '&:not(:last-child)': {
-    borderBottom: 0,
-  },
-  '&::before': {
-    display: 'none',
-  },
-}));
-
-const DATA_GRID_SX: SxProps<Theme> = (theme) => ({
-  '& .MuiDataGrid-columnHeaderTitle, & .MuiDataGrid-cell': {
-    display: 'flex',
-    fontSize: theme.typography.caption.fontSize,
-    whiteSpace: 'normal',
-    lineHeight: 'normal',
-    py: 1,
-    justifyContent: 'flex-start',
-    textAlign: 'left',
-  },
-  '& .MuiDataGrid-cell': {
-    textAlign: 'left',
-  },
-});
-
-interface KeyMeasure {
-  label: string;
-  question: string;
-}
-
-interface MeasureDataPoint {
+type MeasureDataPoint = {
+  type: 'MEASURE';
   id: string;
-  uuid: string;
-  question: string;
-  baselineYear: string | number;
-  unit: string;
-  [year: number]: string | number;
+  isTitle: false;
+  label: string;
+  baselineValue: number | null;
+  unit: UnitType;
+  originalId: string;
+  depth: number;
+  originalMeasureTemplate: MeasureTemplateFragmentFragment;
+  [year: number]: null | number;
+};
+
+type SectionRow = {
+  type: 'SECTION';
+  isTitle: boolean;
+  id: string;
+  label: string;
+  depth: number;
+};
+
+type Row = MeasureDataPoint | SectionRow;
+
+const currentYear = new Date().getFullYear();
+
+function getRowsFromSection(
+  { childSections = [], measureTemplates = [], ...section }: Section,
+  depth = 0,
+  isRoot: boolean = false,
+  baselineYear: number | null = null
+): Row[] {
+  const sectionRow: SectionRow = {
+    type: 'SECTION',
+    isTitle: true,
+    label: section.name,
+    id: section.id,
+    depth,
+  };
+
+  return [
+    ...(isRoot ? [] : [sectionRow]),
+    ...measureTemplates.flatMap(
+      (measure): MeasureDataPoint => ({
+        isTitle: false,
+        type: 'MEASURE',
+        id: measure.uuid,
+        originalId: measure.id,
+        label: measure.name,
+        baselineValue: getMeasureValue(measure, baselineYear),
+        unit: measure.unit,
+        depth: depth + 1,
+        originalMeasureTemplate: measure,
+        ...measure.measure?.dataPoints.reduce(
+          (acc, dataPoint) => {
+            return {
+              ...acc,
+              [dataPoint.year]: dataPoint.value ?? null,
+            };
+          },
+          {} as Record<number, null | number>
+        ),
+      })
+    ),
+    ...childSections.flatMap((section) =>
+      getRowsFromSection(section, depth + 1, false, baselineYear)
+    ),
+  ];
 }
 
-type MeasureSection = Record<string, MeasureDataPoint[]>;
-
-const keyMeasures: Record<string, KeyMeasure> = additionalMeasures.reduce(
-  (acc: Record<string, KeyMeasure>, measure) => {
-    acc[String(measure.uuid)] = {
-      label: measure.label,
-      question: measure.question,
-    };
-    return acc;
+const EDITABLE_COL: Partial<GridColDef> = {
+  editable: true,
+  renderCell: (params: GridRenderCellParams<Row>) => {
+    return <CustomEditComponent {...params} sx={{ mx: 0, my: 1 }} />;
   },
-  {}
-);
+  renderEditCell: (params: GridRenderCellParams<Row>) => (
+    <CustomEditComponent {...params} />
+  ),
+};
 
-function NumericEditComponent(props: GridRenderEditCellParams) {
-  const { colDef } = props;
-
-  if (colDef.type === 'number') {
-    return <CustomEditComponent {...props} />;
+/**
+ * Filter the measure templates to only include the additional
+ * measures used to calculate historical emissions.
+ */
+function filterMeasureTemplates(
+  data: GetMeasureTemplatesQuery | undefined,
+  additionalMeasures: Array<{ uuid: string }>
+) {
+  if (!data?.framework) {
+    return undefined;
   }
 
-  return null;
+  const dataCollectionMap = new Map(
+    data.framework.dataCollection?.descendants.map((section) => [
+      section.uuid,
+      section,
+    ])
+  );
+
+  const allowedMeasureTemplateUuids = new Set(
+    additionalMeasures.map((m) => m.uuid)
+  );
+
+  function getAncestorUuids(parent: { uuid: string } | undefined): string[] {
+    if (!parent?.uuid) {
+      return [];
+    }
+
+    const nextParent = dataCollectionMap.get(parent.uuid);
+
+    return [parent.uuid, ...getAncestorUuids(nextParent?.parent ?? undefined)];
+  }
+
+  const allowedSectionUuids = data.framework.dataCollection?.descendants
+    .map((section) => {
+      if (
+        section.measureTemplates.some((template) =>
+          allowedMeasureTemplateUuids.has(template.uuid)
+        )
+      ) {
+        return [
+          section.uuid,
+          ...getAncestorUuids(section?.parent ?? undefined),
+        ];
+      }
+
+      return undefined;
+    })
+    .flat()
+    .filter(Boolean);
+
+  const allowedSectionUuidsSet = new Set(
+    allowedSectionUuids?.map((uuid) => uuid) ?? []
+  );
+
+  const filteredSections = data.framework.dataCollection?.descendants
+    .filter((section) => allowedSectionUuidsSet.has(section.uuid))
+    .map((section) => ({
+      ...section,
+      measureTemplates: section.measureTemplates.filter((template) =>
+        allowedMeasureTemplateUuids.has(template.uuid)
+      ),
+    }));
+
+  return filteredSections;
 }
 
-export function AdditionalDatasheetEditor() {
-  const baselineYear =
-    useFrameworkInstanceStore((state) => state.baselineYear) ?? 0;
+type DatasheetSectionProps = {
+  section: Section;
+  baselineYear: number;
+};
+
+function isValidYear(yearString: string) {
+  const yearRegex = /^\d{4}$/;
+  if (!yearRegex.test(yearString)) {
+    return false;
+  }
+
+  const year = parseInt(yearString, 10);
+
+  const currentYear = new Date().getFullYear();
+
+  return year >= 1000 && year <= currentYear;
+}
+
+function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
+  const [rowsFailedToSave, setRowsFailedToSave] = useState<
+    { year: string; uuid: string }[]
+  >([]);
+  const { setNotification } = useSnackbar();
+  const singleClickEditProps = useSingleClickEdit();
+  const permissions = usePermissions();
   const selectedInstanceId = useFrameworkInstanceStore(
     (state) => state.selectedInstance
   );
-
-  const { setNotification } = useSnackbar();
-  const [measureSection, setMeasureSection] = useState<MeasureSection>({});
-  const [expanded, setExpanded] = useState<number | null>(0);
-
-  const { data, loading, error } = useQuery<GetMeasureTemplatesQuery>(
-    GET_MEASURE_TEMPLATES,
-    {
-      variables: { frameworkConfigId: selectedInstanceId },
-    }
-  );
-
-  const currentYear = new Date().getFullYear();
 
   const additionalYears = useMemo(
     () =>
@@ -131,112 +224,92 @@ export function AdditionalDatasheetEditor() {
         { length: currentYear - baselineYear - 1 },
         (_, i) => baselineYear + 1 + i
       ),
-    [currentYear, baselineYear]
+    [baselineYear]
   );
 
-  const [updateMeasureDataPoint, { loading: mutationLoading }] = useMutation<
+  const rows = useMemo(
+    () => getRowsFromSection(section, 0, true, baselineYear),
+    [section, baselineYear]
+  );
+
+  const [updateMeasureDataPoint, { loading }] = useMutation<
     UpdateMeasureDataPointMutation,
     UpdateMeasureDataPointMutationVariables
   >(UPDATE_MEASURE_DATAPOINT);
 
-  useEffect(() => {
-    if (data && data.framework) {
-      const grouped: MeasureSection = {};
-      const allMeasureTemplates = [
-        ...(data.framework.dataCollection?.descendants || []),
-        ...(data.framework.futureAssumptions?.descendants || []),
-      ].flatMap((section) => section.measureTemplates);
-
-      allMeasureTemplates.forEach((measureTemplate) => {
-        const keyDriver = keyMeasures[measureTemplate.uuid];
-        if (keyDriver) {
-          const { label, question } = keyDriver;
-          if (!grouped[label]) grouped[label] = [];
-
-          const baselineDataPoint = measureTemplate.measure?.dataPoints.find(
-            (dp) => dp.year === baselineYear
-          );
-
-          const yearData = additionalYears.reduce(
-            (acc, year) => {
-              const dataPoint = measureTemplate.measure?.dataPoints.find(
-                (dp) => dp.year === year
-              );
-              acc[year] =
-                dataPoint?.value !== undefined && dataPoint?.value !== null
-                  ? dataPoint.value
-                  : '';
-              return acc;
-            },
-            {} as Record<number, string | number>
-          );
-
-          grouped[label].push({
-            id: measureTemplate.id,
-            uuid: measureTemplate.uuid,
-            question,
-            baselineYear: baselineDataPoint?.value ?? 'No Data',
-            unit: measureTemplate.unit?.htmlShort ?? 'No data',
-            ...yearData,
-          });
-        }
-      });
-
-      setMeasureSection(grouped);
-    }
-
-    if (error) {
+  const handleProcessRowUpdateError = useCallback(
+    (error: Error) => {
       setNotification({
-        message: 'Failed to fetch data for Additional Datasheet',
+        message: 'Failed to save, please try again',
         extraDetails: error.message,
         severity: 'error',
       });
-    }
-  }, [data, error, setNotification, baselineYear, additionalYears]);
+    },
+    [setNotification]
+  );
 
   const processRowUpdate = useCallback(
-    async (updatedRow: MeasureDataPoint, originalRow: MeasureDataPoint) => {
+    async (updatedRow: Row, originalRow: Row): Promise<Row> => {
+      if (updatedRow.type !== 'MEASURE' || originalRow.type !== 'MEASURE') {
+        return originalRow;
+      }
+
       const changedYearField = Object.keys(updatedRow).find(
         (key) =>
-          updatedRow[key as keyof MeasureDataPoint] !==
-          originalRow[key as keyof MeasureDataPoint]
+          isValidYear(key) &&
+          updatedRow[key as keyof Row] !== originalRow[key as keyof Row]
       );
 
       if (changedYearField) {
         const year = parseInt(changedYearField, 10);
-
-        const newValue =
-          (
-            updatedRow[changedYearField as keyof MeasureDataPoint] as {
-              floatValue?: number;
-            }
-          )?.floatValue ??
-          parseFloat(
-            updatedRow[changedYearField as keyof MeasureDataPoint] as string
-          );
+        const newValue = updatedRow[changedYearField as keyof Row] ?? null;
 
         if (!selectedInstanceId) {
-          console.error('Instance ID is missing.');
-          return updatedRow;
+          throw new Error('No plan selected');
+        }
+
+        if (typeof newValue !== 'number' && newValue !== null) {
+          // Shouldn't occur, the input should always be a number
+          throw new Error('Invalid value');
         }
 
         try {
           await updateMeasureDataPoint({
             variables: {
               frameworkInstanceId: selectedInstanceId,
-              measureTemplateId: updatedRow.id,
+              measureTemplateId: updatedRow.originalId,
               year,
               value: newValue,
             },
+            refetchQueries() {
+              return [
+                {
+                  query: GET_MEASURE_TEMPLATE,
+                  variables: {
+                    id: updatedRow.originalId,
+                    frameworkConfigId: selectedInstanceId,
+                  },
+                },
+              ];
+            },
           });
+
+          if (rowsFailedToSave.find((row) => row.uuid === updatedRow.id)) {
+            setRowsFailedToSave((rows) => [
+              ...rows.filter((row) => row.uuid !== updatedRow.id),
+            ]);
+          }
         } catch (error) {
-          setNotification({
-            message: 'Failed to save, please try again',
-            extraDetails: (error as Error).message,
-            severity: 'error',
-          });
+          setRowsFailedToSave((rows) => [
+            ...rows,
+            { uuid: updatedRow.id, year: changedYearField },
+          ]);
+
+          // Rethrow the error to be caught by onProcessRowUpdateError and prevent exiting edit mode
           throw error;
         }
+
+        return updatedRow;
       }
       return updatedRow;
     },
@@ -246,34 +319,55 @@ export function AdditionalDatasheetEditor() {
   const COLUMNS: GridColDef[] = useMemo(
     () => [
       {
-        headerName: '',
-        field: 'question',
-        flex: 3,
-        renderCell: (params: GridRenderCellParams) => (
-          <Typography
-            variant="body2"
-            style={{ whiteSpace: 'normal', lineHeight: 1.5 }}
-            sx={{ pr: 5 }}
-          >
-            {params.value}
-          </Typography>
-        ),
+        display: 'flex',
+        headerName: 'Label',
+        field: 'label',
+        flex: 2,
+        renderCell: (params: GridRenderCellParams<Row>) => {
+          const isSmallText = params.row.type === 'SECTION';
+
+          return (
+            <Typography
+              sx={{
+                my: 1,
+                ml: params.row.depth,
+                fontWeight: isSmallText ? 'fontWeightMedium' : undefined,
+              }}
+              variant={isSmallText ? 'caption' : 'body2'}
+            >
+              {params.value}
+            </Typography>
+          );
+        },
+        // Stretch title rows to the full width of the table
+        colSpan: (_: any, row: Row) => {
+          if (row.type === 'SECTION') {
+            return COLUMNS.length;
+          }
+
+          return undefined;
+        },
       },
       {
+        display: 'flex',
         headerName: 'Baseline',
-        field: 'baselineYear',
+        field: 'baselineValue',
         flex: 1,
-        renderCell: (params: GridRenderCellParams) => {
-          const value = params.value as number | null;
-          const row = params.row as MeasureDataPoint;
+        renderCell: (params: GridRenderCellParams<Row>) => {
+          const value = params.value;
+          const row = params.row;
 
-          if (value == null) {
+          if (row.type === 'SECTION') {
             return null;
           }
 
-          const precision = getDecimalPrecisionByUnit(row.unit);
+          if (value == null) {
+            return '-';
+          }
 
-          if (isYearMeasure(row.question, row.unit)) {
+          const precision = getDecimalPrecisionByUnit(row.unit.short);
+
+          if (isYearMeasure(row.label, row.unit.short)) {
             return <Typography variant="body2">{Math.round(value)}</Typography>;
           }
 
@@ -287,8 +381,8 @@ export function AdditionalDatasheetEditor() {
         },
 
         renderHeader: () => (
-          <Box sx={{ textAlign: 'center', lineHeight: 1.5 }}>
-            <Typography variant="body2" component="div">
+          <Box sx={{ lineHeight: 1.5 }}>
+            <Typography variant="body2" component="span">
               {baselineYear}
             </Typography>
             <Typography variant="caption" component="div">
@@ -297,22 +391,30 @@ export function AdditionalDatasheetEditor() {
           </Box>
         ),
       },
-      { headerName: 'Unit', field: 'unit', flex: 1 },
+      {
+        headerName: 'Unit',
+        field: 'unit',
+        flex: 1,
+        display: 'flex',
+        valueFormatter: (value: UnitType, row: MeasureDataPoint) =>
+          row.type === 'MEASURE' ? value.long : undefined,
+        renderCell: (params: GridRenderCellParams<Row>) => {
+          return (
+            <Typography key={'unit'} sx={{ my: 1 }} variant={'caption'}>
+              {getUnitName(params.value.long)}
+            </Typography>
+          );
+        },
+      },
       ...additionalYears.map(
         (year) =>
           ({
             headerName: year.toString(),
             field: year.toString(),
-            editable: true,
             flex: 1,
             type: 'number',
             headerAlign: 'left',
-            renderCell: (params: GridRenderCellParams) => (
-              <NumericEditComponent {...params} sx={{ mx: 0 }} />
-            ),
-            renderEditCell: (params: GridRenderEditCellParams) => (
-              <NumericEditComponent {...params} />
-            ),
+            ...EDITABLE_COL,
           }) as GridColDef
       ),
     ],
@@ -320,55 +422,116 @@ export function AdditionalDatasheetEditor() {
   );
 
   return (
+    <DataGrid
+      {...(permissions.edit ? singleClickEditProps : {})}
+      loading={loading}
+      slots={{ footer: CustomFooter }}
+      slotProps={{ footer: { count: rows.length } }}
+      sx={DATA_GRID_SX}
+      isCellEditable={(params) =>
+        !!(permissions.edit && params.colDef.editable)
+      }
+      getRowClassName={(params) => {
+        if (params.row.type === 'SECTION') {
+          const { depth } = params.row;
+          return `row-title ${depth > 1 ? 'row-title--subtitle' : ''}`;
+        }
+
+        return '';
+      }}
+      getCellClassName={(params) =>
+        rowsFailedToSave.find(
+          (row) => row.uuid === params.row.id && row.year === params.field
+        )
+          ? 'cell-error'
+          : ''
+      }
+      getRowHeight={() => 'auto'}
+      getRowId={(row) => row.id}
+      rows={rows}
+      columns={COLUMNS}
+      disableColumnSorting
+      disableColumnFilter
+      disableColumnMenu
+      disableVirtualization
+      processRowUpdate={processRowUpdate}
+      onProcessRowUpdateError={handleProcessRowUpdateError}
+    />
+  );
+}
+
+export function AdditionalDatasheetEditor() {
+  const baselineYear =
+    useFrameworkInstanceStore((state) => state.baselineYear) ?? 0;
+  const selectedInstanceId = useFrameworkInstanceStore(
+    (state) => state.selectedInstance
+  );
+
+  const [expanded, setExpanded] = useState<number | null>(0);
+
+  const { data, loading, error } = useQuery<GetMeasureTemplatesQuery>(
+    GET_MEASURE_TEMPLATES,
+    {
+      variables: { frameworkConfigId: selectedInstanceId },
+    }
+  );
+
+  const filteredData = useMemo(
+    () => filterMeasureTemplates(data, additionalMeasures),
+    [data]
+  );
+
+  const rootSectionUuid = data?.framework?.dataCollection?.uuid;
+
+  const measures = useMemo(
+    () =>
+      mapMeasureTemplatesToRows({
+        uuid: rootSectionUuid ?? '',
+        descendants: filteredData ?? [],
+      }),
+    [filteredData, rootSectionUuid]
+  );
+
+  if (loading) {
+    return <LoadingCard />;
+  }
+
+  if (error) {
+    captureException(error);
+
+    return <ErrorComponent error={error} />;
+  }
+
+  return (
     <div>
-      {loading ? (
-        <Skeleton variant="rectangular" width="100%" height={400} />
-      ) : (
-        Object.entries(measureSection).map(([label, measures], index) => {
-          return (
-            <Accordion
-              key={`${label}-${index}`}
-              expanded={expanded === index}
-              onChange={(_event, isExpanded) =>
-                setExpanded(isExpanded ? index : null)
-              }
+      {measures.map((measure, index) => {
+        return (
+          <Accordion
+            slotProps={{ transition: { unmountOnExit: true } }}
+            key={measure.id}
+            expanded={expanded === index}
+            onChange={(_event, isExpanded) =>
+              setExpanded(isExpanded ? index : null)
+            }
+          >
+            <MuiAccordionSummary
+              expandIcon={<ChevronDown size={18} />}
+              aria-controls={`${measure.id}-content`}
+              id={`${measure.id}-header`}
             >
-              <MuiAccordionSummary
-                expandIcon={<ChevronDown size={18} />}
-                aria-controls={`${label}-content`}
-                id={`${label}-header`}
-              >
-                <Typography>{label}</Typography>
-              </MuiAccordionSummary>
-              <MuiAccordionDetails>
-                <Box sx={{ height: 400 }}>
-                  <DataGrid
-                    rows={measures}
-                    columns={COLUMNS}
-                    sx={DATA_GRID_SX}
-                    loading={loading || mutationLoading}
-                    getRowHeight={() => 'auto'}
-                    disableColumnSorting
-                    disableColumnFilter
-                    disableColumnMenu
-                    processRowUpdate={processRowUpdate}
-                    onProcessRowUpdateError={(error) =>
-                      setNotification({
-                        message: 'Failed to save, please try again',
-                        extraDetails: error.message,
-                        severity: 'error',
-                      })
-                    }
-                    slots={{ footer: CustomFooter }}
-                    slotProps={{ footer: { count: measures.length } }}
-                    hideFooterPagination
-                  />
-                </Box>
-              </MuiAccordionDetails>
-            </Accordion>
-          );
-        })
-      )}
+              <Typography>{measure.name}</Typography>
+            </MuiAccordionSummary>
+            <AccordionDetails>
+              <Box sx={{ height: 400 }}>
+                <DatasheetSection
+                  section={measure}
+                  baselineYear={baselineYear}
+                />
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
     </div>
   );
 }

--- a/components/DataCollection.tsx
+++ b/components/DataCollection.tsx
@@ -88,7 +88,6 @@ const DataCollection = ({ measureTemplates }: Props) => {
           sectors. This phase focuses on gathering raw data to establish a
           baseline for your city&apos;s climate initiatives.
         </Typography>
-        {/* TODO: Fallback component */}
         {!!dataMeasures && (
           <DatasheetEditor sections={dataMeasures} withIndexes />
         )}
@@ -99,7 +98,6 @@ const DataCollection = ({ measureTemplates }: Props) => {
           aligned with the city&apos;s Climate Action Plan, indicating the
           extent to which the city aims to achieve decarbonisation goals.
         </Typography>
-        {/* TODO: Fallback component */}
         {!!assumptionMeasures && (
           <DatasheetEditor sections={assumptionMeasures} />
         )}

--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -60,7 +60,7 @@ import { PriorityBadge } from './PriorityBadge';
 import { useSnackbar } from './SnackbarProvider';
 import { usePermissions } from '@/hooks/use-user-profile';
 
-const Accordion = styled((props: AccordionProps) => (
+export const Accordion = styled((props: AccordionProps) => (
   <MuiAccordion disableGutters elevation={0} square {...props} />
 ))(({ theme }) => ({
   '&:first-of-type': {
@@ -105,7 +105,7 @@ const rowSummarySx: SxProps<Theme> = (theme) => ({
 });
 
 // Override styles colors of title sections
-const DATA_GRID_SX: SxProps<Theme> = (theme) => ({
+export const DATA_GRID_SX: SxProps<Theme> = (theme) => ({
   '& .MuiDataGrid-columnHeaderTitle': {
     fontSize: theme.typography.caption.fontSize,
     whiteSpace: 'normal',
@@ -233,6 +233,7 @@ export default function CustomEditComponent({
       <NumberInput
         {...commonProps}
         key={key}
+        autoComplete="off"
         fullWidth
         onKeyDown={handleEscape}
         onValueChange={permissions.edit ? handleNumberValueChange : undefined}
@@ -250,6 +251,7 @@ export default function CustomEditComponent({
       <TextField
         {...commonProps}
         key={key}
+        autoComplete="off"
         disabled={!permissions.edit}
         onKeyDown={handleEscape}
         onChange={permissions.edit ? handleValueChange : undefined}
@@ -282,7 +284,7 @@ export default function CustomEditComponent({
 /**
  * Support editable cells with a single click, rather than the MUI default of double clicking
  */
-function useSingleClickEdit() {
+export function useSingleClickEdit() {
   const [cellModesModel, setCellModesModel] = useState<GridCellModesModel>({});
 
   const handleCellClick = useCallback(
@@ -592,7 +594,7 @@ type SumPercentRow = {
 
 type Row = MeasureRow | SectionRow | SumPercentRow;
 
-const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
+export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   padding: theme.spacing(2),
   borderTop: '1px solid rgba(0, 0, 0, .125)',
 }));

--- a/constants/measure-overrides.ts
+++ b/constants/measure-overrides.ts
@@ -34,140 +34,101 @@ export const SECTIONS_SUM_100_PERCENT = [
 export const additionalMeasures = [
   {
     uuid: 'c3f157c0-ae56-470f-9ac7-e7ac0080626d',
-    question:
-      'What was the total distance travelled by passenger cars and motorcycles?',
     id: 207,
     label: 'Passenger transportation',
   },
   {
     uuid: '0791d065-3de0-4667-939f-056055677973',
-    question: 'What was the total distance travelled by buses?',
     id: 208,
     label: 'Passenger transportation',
   },
   {
     uuid: '2be6f9ef-1745-40bf-9498-e9eeb4fdb984',
-    question:
-      'What percentage of passenger cars and motorcycles were fully electric (excluding hybrids)?',
     id: 224,
     label: 'Passenger transportation',
   },
   {
     uuid: '8a0ddf12-611d-45c0-b51b-c5722f5fb88c',
-    question:
-      'What percentage of buses were fully electric (excluding hybrids)?',
     id: 226,
     label: 'Passenger transportation',
   },
   {
     uuid: 'beac92cf-c0c5-4921-8019-1a464d2a4fc0',
-    question:
-      'How many light duty trucks (<3.5 tonnes) were registered in the city?',
     id: 242,
     label: 'Freight transportation',
   },
   {
     uuid: '3f433a95-e490-48c5-b629-3cffa0a132bb',
-    question:
-      'How many heavy duty trucks (>3.5 tonnes) were registered in the city?',
     id: 243,
     label: 'Freight transportation',
   },
   {
     uuid: 'f3fc1e37-d5bf-42d4-ae1e-d5ddc8acfc08',
-    question:
-      'What percentage of light duty trucks were fully electric (excluding hybrids)?',
     id: 404,
     label: 'Freight transportation',
   },
   {
     uuid: '89c7e112-6102-463a-94e8-c34a6a5d943a',
-    question:
-      'What percentage of heavy duty trucks were fully electric (excluding hybrids)?',
     id: 405,
     label: 'Freight transportation',
   },
   {
     uuid: 'f0401b8f-b988-45f8-bb09-252c33ce330f',
-    question:
-      "What percentage of the city's total building stock underwent energy efficiency renovations?",
     id: 247,
     label: 'Buildings & heating',
   },
   {
     uuid: '0ae5fb06-48a4-4774-9799-ccfa4e8f44a5',
-    question:
-      'What was the total heating demand (including space heating, domestic hot water, and heat for cooking)?',
     id: 252,
     label: 'Buildings & heating',
   },
   {
     uuid: '83080b15-af7d-44e9-bab2-cefe151879b3',
-    question:
-      'What percentage of the total heating demand was met by: District heating?',
     id: 253,
     label: 'Buildings & heating',
   },
   {
     uuid: 'b38b5eb7-fb3c-4cfe-999e-29a349d302cd',
-    question:
-      'What percentage of the total heating demand was met by: Local heating?',
     id: 254,
     label: 'Buildings & heating',
   },
   {
     uuid: 'ef9b2521-c413-4513-8251-a80700d2e558',
-    question:
-      'What percentage of district heating was provided by electric heat pumps?',
     id: 256,
     label: 'Buildings & heating',
   },
   {
     uuid: '804ac52f-8c7a-4b79-a56a-ed50f62ba8ad',
-    question:
-      'What percentage of local heating was provided by: Electric heat pumps?',
     id: 262,
     label: 'Buildings & heating',
   },
   {
     uuid: 'c8091681-cc83-416c-b4d2-7965b441e94e',
-    question:
-      'What percentage of local heating was provided by: Biobased / solar water heating?',
     id: 263,
     label: 'Buildings & heating',
   },
   {
     uuid: '3b58ecda-77bb-4ac6-80bf-7f802442bbb4',
-    question:
-      'What percentage of local heating was provided by: Inefficient electric heating (not heat pumps)?',
     id: 255,
     label: 'Buildings & heating',
   },
   {
     uuid: '5f7c8175-d3ae-4e05-9179-325b84934ead',
-    question:
-      'What was the total electricity demand within the city boundaries?',
     id: 272,
     label: 'Electricity',
   },
   {
     uuid: 'b132697d-6a72-476c-aed5-d3fa3886d943',
-    question:
-      'What was the share of electricity production from renewable sources (excluding local solar PV)?',
     id: 273,
     label: 'Electricity',
   },
   {
     uuid: 'fbf3fa68-30be-47c5-a368-decd9d6f16e2',
-    question:
-      'What were the total CO2e emissions from industrial processes and product use (IPPU)?',
     id: 327,
     label: 'Greenhouse gases',
   },
   {
     uuid: '58c99d80-8b05-4573-8291-9252560414fd',
-    question:
-      'What were the total CO2e emissions from other sources not included in previous categories?',
     id: 329,
     label: 'Greenhouse gases',
   },


### PR DESCRIPTION
This added some complexity because we needed to keep the parent sections which additional measures belong to. I used as much as possible from the core `DatasheetEditor` component now that the rendering is quite similar. I also had move things around which may make it trickier to review, sorry!

![image](https://github.com/user-attachments/assets/781ec7ef-ac33-4b56-8be1-a31030ee8b5c)