### PR TITLE
Support setting a custom target year when creating a plan

### DIFF
--- a/components/DataCollection.tsx
+++ b/components/DataCollection.tsx
@@ -49,6 +49,10 @@ const DataCollection = ({ measureTemplates }: Props) => {
     useFrameworkInstanceStore,
     (state) => state.baselineYear
   );
+  const { data: targetYear } = useStore(
+    useFrameworkInstanceStore,
+    (state) => state.targetYear
+  );
 
   const handleChange = (event: React.SyntheticEvent, newSelected: TTab) => {
     setSelectedTab(newSelected);
@@ -76,7 +80,7 @@ const DataCollection = ({ measureTemplates }: Props) => {
             {...a11yProps('data')}
           />
           <Tab
-            label="Future assumptions (2030)"
+            label={`Future assumptions (${targetYear})`}
             value="assumptions"
             {...a11yProps('assumptions')}
           />

--- a/components/DataCollection.tsx
+++ b/components/DataCollection.tsx
@@ -8,6 +8,7 @@ import { GetMeasureTemplatesQuery } from '@/types/__generated__/graphql';
 import { mapMeasureTemplatesToRows } from '@/utils/measures';
 import useStore from '@/store/use-store';
 import { useFrameworkInstanceStore } from '@/store/selected-framework-instance';
+import { useDefaultTargetYear } from '@/hooks/use-framework-settings';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -54,6 +55,8 @@ const DataCollection = ({ measureTemplates }: Props) => {
     (state) => state.targetYear
   );
 
+  const defaultTargetYear = useDefaultTargetYear();
+
   const handleChange = (event: React.SyntheticEvent, newSelected: TTab) => {
     setSelectedTab(newSelected);
   };
@@ -80,7 +83,7 @@ const DataCollection = ({ measureTemplates }: Props) => {
             {...a11yProps('data')}
           />
           <Tab
-            label={`Future assumptions (${targetYear})`}
+            label={`Future assumptions (${targetYear || defaultTargetYear})`}
             value="assumptions"
             {...a11yProps('assumptions')}
           />

--- a/components/DatasheetEditor.tsx
+++ b/components/DatasheetEditor.tsx
@@ -427,13 +427,24 @@ const EDITABLE_COL: Partial<GridColDef> = {
         return null;
       }
 
-      return <TotalPercentage total={params.row.total} />;
+      return (
+        <TotalPercentage
+          key={`${params.field}-${params.row.id}`}
+          total={params.row.total}
+        />
+      );
     }
 
-    return <CustomEditComponent {...params} sx={{ mx: 0, my: 1 }} />;
+    return (
+      <CustomEditComponent
+        key={`${params.field}-${params.row.id}`}
+        {...params}
+        sx={{ mx: 0, my: 1 }}
+      />
+    );
   },
   renderEditCell: (params: GridRenderCellParams<Row>) => (
-    <CustomEditComponent {...params} />
+    <CustomEditComponent key={`${params.field}-${params.id}`} {...params} />
   ),
 };
 
@@ -451,6 +462,7 @@ const GRID_COL_DEFS: GridColDef[] = [
 
       return (
         <Typography
+          key={`label-${params.row.id}`}
           sx={{
             my: 1,
             ml: params.row.depth,
@@ -495,7 +507,11 @@ const GRID_COL_DEFS: GridColDef[] = [
         return null;
       }
       return (
-        <Typography key={'unit'} sx={{ my: 1 }} variant={'caption'}>
+        <Typography
+          key={`unit-${params.row.id}`}
+          sx={{ my: 1 }}
+          variant={'caption'}
+        >
           {getUnitName(params.value.long)}
         </Typography>
       );
@@ -512,6 +528,7 @@ const GRID_COL_DEFS: GridColDef[] = [
       if (params.row.type === 'SUM_PERCENT') {
         return (
           <TotalPercentage
+            key={`fallback-${params.row.id}`}
             overrideIsValid
             total={
               typeof params.row.fallbackTotal === 'number'
@@ -547,7 +564,11 @@ const GRID_COL_DEFS: GridColDef[] = [
     flex: 1,
     renderCell: (params) =>
       !!params.value && (
-        <PriorityBadge variant="badge" priority={params.value} />
+        <PriorityBadge
+          key={`priority-${params.row.id}`}
+          variant="badge"
+          priority={params.value}
+        />
       ),
   },
   {

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -153,29 +153,33 @@ export function InstanceControlBar() {
         firstInstance.organizationName ?? undefined,
         firstInstance.baselineYear
       );
-      setNotification({
-        message: 'Plan selection updated',
-        extraDetails: (
-          <>
-            <Typography
-              variant="body2"
-              component="span"
-              fontWeight="fontWeightBold"
-              color="primary.dark"
-            >
-              {firstInstance.organizationName}
-            </Typography>{' '}
-            has been automatically set as your active plan
-          </>
-        ),
-        severity: 'info',
-      });
+
+      if (configsCount > 1) {
+        setNotification({
+          message: 'Plan selection updated',
+          extraDetails: (
+            <>
+              <Typography
+                variant="body2"
+                component="span"
+                fontWeight="fontWeightBold"
+                color="primary.dark"
+              >
+                {firstInstance.organizationName}
+              </Typography>{' '}
+              has been automatically set as your active plan
+            </>
+          ),
+          severity: 'info',
+        });
+      }
     }
   }, [
     instanceData,
     setInstance,
     isInstanceStoreInitialized,
     selectedInstanceId,
+    setNotification,
   ]);
 
   if (instanceError) {
@@ -195,6 +199,7 @@ export function InstanceControlBar() {
           frameworkId: 'nzc',
           name: data.planName,
           baselineYear: Number(data.baselineYear),
+          targetYear: Number(data.targetYear),
           slug: kebabCase(data.planName),
           population: Number(data.population),
           renewableMix:

--- a/components/InstanceControlBar.tsx
+++ b/components/InstanceControlBar.tsx
@@ -59,7 +59,8 @@ function InstanceSelector({
       setInstance(
         instance.id,
         instance.organizationName ?? undefined,
-        instance.baselineYear
+        instance.baselineYear,
+        instance.targetYear ?? undefined
       );
     }
   }
@@ -151,7 +152,8 @@ export function InstanceControlBar() {
       setInstance(
         firstInstance.id,
         firstInstance.organizationName ?? undefined,
-        firstInstance.baselineYear
+        firstInstance.baselineYear,
+        firstInstance.targetYear ?? undefined
       );
 
       if (configsCount > 1) {
@@ -215,7 +217,8 @@ export function InstanceControlBar() {
         setInstance(
           instance.id,
           instance.organizationName ?? undefined,
-          instance.baselineYear
+          instance.baselineYear,
+          instance.targetYear ?? undefined
         );
       }
 

--- a/components/SnackbarProvider.tsx
+++ b/components/SnackbarProvider.tsx
@@ -16,8 +16,8 @@ import {
 import { Alert, AlertProps, AlertTitle, Snackbar } from '@mui/material';
 
 type Notification = {
-  message: string;
-  extraDetails?: string;
+  message: ReactNode;
+  extraDetails?: ReactNode;
   severity: AlertProps['severity'];
 };
 
@@ -73,11 +73,13 @@ export function SnackbarWrapper() {
       open={isVisible}
       autoHideDuration={10000}
       onClose={handleSnackbarClose}
+      sx={{ mt: 6 }}
     >
       <Alert
+        elevation={2}
         onClose={handleClose}
         severity={notification?.severity}
-        variant="filled"
+        variant="standard"
         sx={{ width: '100%' }}
       >
         {notification?.extraDetails ? (

--- a/constants/faqs.tsx
+++ b/constants/faqs.tsx
@@ -78,7 +78,7 @@ export const FAQS = [
     title:
       'The model calculates carbon and costs and benefits for four major sectors (Transportation, Buildings & Heating, Electricity, and Waste).  How does it handle emissions outside of those four main sectors?',
     description:
-      'All emissions that do not fall into the four main sectors are grouped together in a sector called “Other”.  This sector includes emissions from IPPU and AFOLU among other emissions.  The model does not calculate the carbon reductions or costs and benefits in the “Other” sector.  There is an input on the Future Assumptions tab where you can say how much you believe this “Other” sector will decline in emissions through 2030 so these emissions can be included in your planning.',
+      'All emissions that do not fall into the four main sectors are grouped together in a sector called “Other”.  This sector includes emissions from IPPU and AFOLU among other emissions.  The model does not calculate the carbon reductions or costs and benefits in the “Other” sector.  There is an input on the Future Assumptions tab where you can say how much you believe this “Other” sector will decline in emissions through the target year so these emissions can be included in your planning.',
   },
 
   {
@@ -143,9 +143,9 @@ export const FAQS = [
 
   {
     title:
-      'The model calculates the carbon reduction from the 2030 Business as Usual (BAU) case.  How is the BAU case calculated?',
+      'The model calculates the carbon reduction from the Business as Usual (BAU) case.  How is the BAU case calculated?',
     description:
-      'The BAU 2030 case is designed to represent what would have happened if you had not implemented your Climate Action Plan.  It increases carbon over time based on population growth and reduces carbon over time through the natural replacement of worn-out equipment (cars, trucks, heating etc.) with newer more efficient fossil fuel equipment.',
+      'The BAU case is designed to represent what would have happened if you had not implemented your Climate Action Plan.  It increases carbon over time based on population growth and reduces carbon over time through the natural replacement of worn-out equipment (cars, trucks, heating etc.) with newer more efficient fossil fuel equipment.',
   },
 
   {

--- a/constants/intro-content.ts
+++ b/constants/intro-content.ts
@@ -14,7 +14,7 @@ export const benefits = [
   {
     icon: '/images/illustrations/undraw_navigator_a479.svg',
     title: 'Decarbonisation Roadmap',
-    text: "NetZeroPlanner generates a customised roadmap for your city's journey to climate neutrality by 2030.",
+    text: "NetZeroPlanner generates a customised roadmap for your city's journey to climate neutrality.",
   },
   {
     icon: '/images/illustrations/undraw_term_sheet_re_ju7s.svg',

--- a/hooks/use-framework-settings.ts
+++ b/hooks/use-framework-settings.ts
@@ -5,3 +5,9 @@ import { GetFrameworkSettingsQuery } from '@/types/__generated__/graphql';
 export function useSuspenseFrameworkSettings() {
   return useSuspenseQuery<GetFrameworkSettingsQuery>(GET_FRAMEWORK_SETTINGS);
 }
+
+export function useDefaultTargetYear() {
+  const result = useSuspenseFrameworkSettings();
+
+  return result.data?.framework?.defaults.targetYear.default ?? null;
+}

--- a/hooks/use-framework-settings.ts
+++ b/hooks/use-framework-settings.ts
@@ -1,0 +1,7 @@
+import { useSuspenseQuery } from '@apollo/client';
+import { GET_FRAMEWORK_SETTINGS } from '@/queries/framework/get-framework-settings';
+import { GetFrameworkSettingsQuery } from '@/types/__generated__/graphql';
+
+export function useSuspenseFrameworkSettings() {
+  return useSuspenseQuery<GetFrameworkSettingsQuery>(GET_FRAMEWORK_SETTINGS);
+}

--- a/queries/framework/create-framework-config.ts
+++ b/queries/framework/create-framework-config.ts
@@ -4,6 +4,7 @@ export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
   mutation CreateNZCFramework(
     $frameworkId: ID!
     $baselineYear: Int!
+    $targetYear: Int!
     $population: Int!
     $name: String!
     $slug: ID!
@@ -14,6 +15,7 @@ export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
       configInput: {
         frameworkId: $frameworkId
         baselineYear: $baselineYear
+        targetYear: $targetYear
         name: $name
         instanceIdentifier: $slug
       }
@@ -28,6 +30,7 @@ export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
         id
         organizationName
         baselineYear
+        targetYear
         viewUrl
         resultsDownloadUrl
         # Return the updated full list of framework configs to automatically update the cache
@@ -39,6 +42,7 @@ export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
             resultsDownloadUrl
             organizationName
             baselineYear
+            targetYear
           }
         }
       }

--- a/queries/framework/get-framework-config.ts
+++ b/queries/framework/get-framework-config.ts
@@ -8,6 +8,7 @@ export const GET_FRAMEWORK_CONFIG = gql`
         id
         organizationName
         baselineYear
+        targetYear
         viewUrl
         resultsDownloadUrl
       }
@@ -23,6 +24,7 @@ export const GET_FRAMEWORK_CONFIGS = gql`
         id
         organizationName
         baselineYear
+        targetYear
         viewUrl
         resultsDownloadUrl
       }

--- a/queries/framework/get-framework-settings.ts
+++ b/queries/framework/get-framework-settings.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const GET_FRAMEWORK_SETTINGS = gql`
+  query GetFrameworkSettings {
+    framework(identifier: "nzc") {
+      id
+      defaults {
+        targetYear {
+          min
+          max
+          default
+        }
+        baselineYear {
+          min
+          max
+          default
+        }
+      }
+    }
+  }
+`;

--- a/store/selected-framework-instance.ts
+++ b/store/selected-framework-instance.ts
@@ -5,10 +5,12 @@ type Store = {
   selectedInstance: string | null;
   name: string | null;
   baselineYear: number | null;
+  targetYear: number | null;
   setInstance: (
     instanceId: string | null,
     name?: string,
-    baselineYear?: number
+    baselineYear?: number,
+    targetYear?: number
   ) => void;
 };
 
@@ -18,11 +20,13 @@ export const useFrameworkInstanceStore = create(
       selectedInstance: null,
       name: null,
       baselineYear: null,
-      setInstance(instanceId, name, baselineYear) {
+      targetYear: null,
+      setInstance(instanceId, name, baselineYear, targetYear) {
         set({
           selectedInstance: instanceId,
           name: name ?? null,
           baselineYear: baselineYear ?? null,
+          targetYear: targetYear ?? null,
         });
       },
     }),

--- a/theme/overrides.ts
+++ b/theme/overrides.ts
@@ -202,5 +202,24 @@ export function getOverrides(theme: Theme): ThemeOptions['components'] {
         },
       },
     },
+    MuiAlert: {
+      styleOverrides: {
+        standardError: {
+          borderWidth: 2,
+          borderStyle: 'solid',
+          borderColor: theme.palette.error.main,
+        },
+        standardWarning: {
+          borderWidth: 2,
+          borderStyle: 'solid',
+          borderColor: theme.palette.warning.main,
+        },
+        standardInfo: {
+          borderWidth: 2,
+          borderStyle: 'solid',
+          borderColor: theme.palette.info.main,
+        },
+      },
+    },
   };
 }

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -2243,6 +2243,7 @@ export type ProfileQuery = (
 export type CreateNzcFrameworkMutationVariables = Exact<{
   frameworkId: Scalars['ID']['input'];
   baselineYear: Scalars['Int']['input'];
+  targetYear: Scalars['Int']['input'];
   population: Scalars['Int']['input'];
   name: Scalars['String']['input'];
   slug: Scalars['ID']['input'];
@@ -2254,9 +2255,9 @@ export type CreateNzcFrameworkMutationVariables = Exact<{
 export type CreateNzcFrameworkMutation = (
   { createNzcFrameworkConfig?: (
     { ok: boolean, frameworkConfig?: (
-      { id: string, organizationName?: string | null, baselineYear: number, viewUrl?: string | null, resultsDownloadUrl?: string | null, framework: (
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, framework: (
         { id: string, configs: Array<(
-          { id: string, viewUrl?: string | null, resultsDownloadUrl?: string | null, organizationName?: string | null, baselineYear: number }
+          { id: string, viewUrl?: string | null, resultsDownloadUrl?: string | null, organizationName?: string | null, baselineYear: number, targetYear?: number | null }
           & { __typename?: 'FrameworkConfig' }
         )> }
         & { __typename?: 'Framework' }

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -2290,7 +2290,7 @@ export type GetFrameworkConfigQueryVariables = Exact<{
 export type GetFrameworkConfigQuery = (
   { framework?: (
     { id: string, config?: (
-      { id: string, organizationName?: string | null, baselineYear: number, viewUrl?: string | null, resultsDownloadUrl?: string | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
       & { __typename?: 'FrameworkConfig' }
     ) | null }
     & { __typename?: 'Framework' }
@@ -2304,7 +2304,7 @@ export type GetFrameworkConfigsQueryVariables = Exact<{ [key: string]: never; }>
 export type GetFrameworkConfigsQuery = (
   { framework?: (
     { id: string, configs: Array<(
-      { id: string, organizationName?: string | null, baselineYear: number, viewUrl?: string | null, resultsDownloadUrl?: string | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
       & { __typename?: 'FrameworkConfig' }
     )> }
     & { __typename?: 'Framework' }

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -180,6 +180,7 @@ export type ActionNode = NodeInterface & {
   targetYearGoal?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
   upstreamNodes: Array<NodeInterface>;
+  visualizations?: Maybe<Array<VisualizationEntry>>;
 };
 
 
@@ -205,6 +206,7 @@ export type ActionNodeMetricArgs = {
 
 
 export type ActionNodeMetricDimArgs = {
+  includeScenarioKinds?: InputMaybe<Array<ScenarioKind>>;
   withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -382,7 +384,12 @@ export type DeleteFrameworkConfigMutation = {
   ok?: Maybe<Scalars['Boolean']['output']>;
 };
 
-/** An enumeration. */
+/** Desired (benificial) direction for the values of the output of a node */
+export enum DesiredOutcome {
+  Decreasing = 'decreasing',
+  Increasing = 'increasing'
+}
+
 export enum DimensionKind {
   Common = 'COMMON',
   Node = 'NODE',
@@ -412,10 +419,10 @@ export type DimensionalMetricType = {
   goals: Array<DimensionalMetricGoalEntry>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
-  normalizedBy?: Maybe<Node>;
+  normalizedBy?: Maybe<NormalizerNodeType>;
   stackable: Scalars['Boolean']['output'];
   unit: UnitType;
-  values: Array<Maybe<Scalars['Float']['output']>>;
+  values: Array<Scalars['Float']['output']>;
   years: Array<Scalars['Int']['output']>;
 };
 
@@ -533,6 +540,7 @@ export type Framework = {
   __typename?: 'Framework';
   config?: Maybe<FrameworkConfig>;
   configs: Array<FrameworkConfig>;
+  defaults: FrameworkDefaultsType;
   description: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   identifier: Scalars['String']['output'];
@@ -629,6 +637,7 @@ export type FrameworkConfig = {
   organizationSlug?: Maybe<Scalars['String']['output']>;
   /** URL for downloading a results file */
   resultsDownloadUrl?: Maybe<Scalars['String']['output']>;
+  targetYear?: Maybe<Scalars['Int']['output']>;
   userPermissions?: Maybe<UserPermissions>;
   userRoles?: Maybe<Array<Scalars['String']['output']>>;
   uuid: Scalars['UUID']['output'];
@@ -645,8 +654,16 @@ export type FrameworkConfigInput = {
   name: Scalars['String']['input'];
   /** Name of the organization. If not set, it will be determined through the user's credentials, if possible. */
   organizationName?: InputMaybe<Scalars['String']['input']>;
+  /** Target year for model. */
+  targetYear?: InputMaybe<Scalars['Int']['input']>;
   /** UUID for the new framework config. If not set, will be generated automatically. */
   uuid?: InputMaybe<Scalars['UUID']['input']>;
+};
+
+export type FrameworkDefaultsType = {
+  __typename?: 'FrameworkDefaultsType';
+  baselineYear: MinMaxDefaultIntType;
+  targetYear: MinMaxDefaultIntType;
 };
 
 /** An enumeration. */
@@ -741,6 +758,12 @@ export type InstanceBasicConfiguration = {
   isProtected: Scalars['Boolean']['output'];
   supportedLanguages: Array<Scalars['String']['output']>;
   themeIdentifier: Scalars['String']['output'];
+};
+
+export type InstanceContext = {
+  hostname?: InputMaybe<Scalars['String']['input']>;
+  identifier?: InputMaybe<Scalars['ID']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InstanceFeaturesType = {
@@ -1082,6 +1105,13 @@ export type MetricYearlyGoalType = {
   year: Scalars['Int']['output'];
 };
 
+export type MinMaxDefaultIntType = {
+  __typename?: 'MinMaxDefaultIntType';
+  default?: Maybe<Scalars['Int']['output']>;
+  max?: Maybe<Scalars['Int']['output']>;
+  min?: Maybe<Scalars['Int']['output']>;
+};
+
 /** An enumeration. */
 export enum ModelAction {
   Add = 'ADD',
@@ -1162,6 +1192,7 @@ export type MutationsUpdateFrameworkConfigArgs = {
   organizationIdentifier?: InputMaybe<Scalars['String']['input']>;
   organizationName?: InputMaybe<Scalars['String']['input']>;
   organizationSlug?: InputMaybe<Scalars['String']['input']>;
+  targetYear?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1219,6 +1250,7 @@ export type Node = NodeInterface & {
   unit?: Maybe<UnitType>;
   upstreamActions?: Maybe<Array<ActionNode>>;
   upstreamNodes: Array<NodeInterface>;
+  visualizations?: Maybe<Array<VisualizationEntry>>;
 };
 
 
@@ -1244,6 +1276,7 @@ export type NodeMetricArgs = {
 
 
 export type NodeMetricDimArgs = {
+  includeScenarioKinds?: InputMaybe<Array<ScenarioKind>>;
   withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -1295,6 +1328,7 @@ export type NodeInterface = {
   targetYearGoal?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
   upstreamNodes: Array<NodeInterface>;
+  visualizations?: Maybe<Array<VisualizationEntry>>;
 };
 
 
@@ -1320,6 +1354,7 @@ export type NodeInterfaceMetricArgs = {
 
 
 export type NodeInterfaceMetricDimArgs = {
+  includeScenarioKinds?: InputMaybe<Array<ScenarioKind>>;
   withScenarios?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -1336,6 +1371,12 @@ export type NormalizationType = {
   isActive: Scalars['Boolean']['output'];
   label: Scalars['String']['output'];
   normalizer: Node;
+};
+
+export type NormalizerNodeType = {
+  __typename?: 'NormalizerNodeType';
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type NumberParameterType = ParameterInterface & {
@@ -2109,6 +2150,44 @@ export type UserType = {
   lastName: Scalars['String']['output'];
 };
 
+export type VisualizationEntry = {
+  id: Scalars['ID']['output'];
+  kind: VisualizationKind;
+  label?: Maybe<Scalars['String']['output']>;
+};
+
+export type VisualizationGroup = VisualizationEntry & {
+  __typename?: 'VisualizationGroup';
+  children: Array<VisualizationEntry>;
+  id: Scalars['ID']['output'];
+  kind: VisualizationKind;
+  label?: Maybe<Scalars['String']['output']>;
+};
+
+export enum VisualizationKind {
+  Group = 'group',
+  Node = 'node'
+}
+
+export type VisualizationNodeDimension = {
+  __typename?: 'VisualizationNodeDimension';
+  categories?: Maybe<Array<Scalars['String']['output']>>;
+  flatten?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['String']['output'];
+};
+
+export type VisualizationNodeOutput = VisualizationEntry & {
+  __typename?: 'VisualizationNodeOutput';
+  desiredOutcome: DesiredOutcome;
+  dimensions: Array<VisualizationNodeDimension>;
+  id: Scalars['ID']['output'];
+  kind: VisualizationKind;
+  label?: Maybe<Scalars['String']['output']>;
+  metricDim?: Maybe<DimensionalMetricType>;
+  nodeId: Scalars['String']['output'];
+  scenarios?: Maybe<Array<Scalars['String']['output']>>;
+};
+
 export type YearlyValue = {
   __typename?: 'YearlyValue';
   value: Scalars['Float']['output'];
@@ -2227,6 +2306,26 @@ export type GetFrameworkConfigsQuery = (
       { id: string, organizationName?: string | null, baselineYear: number, viewUrl?: string | null, resultsDownloadUrl?: string | null }
       & { __typename?: 'FrameworkConfig' }
     )> }
+    & { __typename?: 'Framework' }
+  ) | null }
+  & { __typename?: 'Query' }
+);
+
+export type GetFrameworkSettingsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetFrameworkSettingsQuery = (
+  { framework?: (
+    { id: string, defaults: (
+      { targetYear: (
+        { min?: number | null, max?: number | null, default?: number | null }
+        & { __typename?: 'MinMaxDefaultIntType' }
+      ), baselineYear: (
+        { min?: number | null, max?: number | null, default?: number | null }
+        & { __typename?: 'MinMaxDefaultIntType' }
+      ) }
+      & { __typename?: 'FrameworkDefaultsType' }
+    ) }
     & { __typename?: 'Framework' }
   ) | null }
   & { __typename?: 'Query' }

--- a/types/__generated__/possible_types.json
+++ b/types/__generated__/possible_types.json
@@ -48,6 +48,10 @@
       "TextBlock",
       "TimeBlock",
       "URLBlock"
+    ],
+    "VisualizationEntry": [
+      "VisualizationGroup",
+      "VisualizationNodeOutput"
     ]
   }
 }


### PR DESCRIPTION
- Add a _Target year_  number field when creating a plan
  - Apply validation to the target year and baseline years based on the new query to fetch min and max values (`queries/framework/get-framework-settings.ts`)
- Remove all hard coded references to _2030_ as the target year and display the target year on the future assumptions tab

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/59ce3b36-321f-4e2f-84b9-bfe684d485f4" />

<img width="1336" alt="image" src="https://github.com/user-attachments/assets/4daabe86-355f-4512-bb5d-98003dfc9d99" />

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/6837023c-060b-4b1f-a86d-adccb8ddcbf3" />
