### PR TITLE
Hide year bound measure templates which are outside of the baseline to target year range

### DIFF
--- a/components/AdditionalDatasheetEditor.tsx
+++ b/components/AdditionalDatasheetEditor.tsx
@@ -462,6 +462,7 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
 export function AdditionalDatasheetEditor() {
   const plan = useSuspenseSelectedPlanConfig();
   const baselineYear = plan?.baselineYear ?? 0;
+  const targetYear = plan?.targetYear ?? null;
   const [expanded, setExpanded] = useState<number | null>(0);
 
   const { data, loading, error } = useQuery<GetMeasureTemplatesQuery>(
@@ -484,10 +485,14 @@ export function AdditionalDatasheetEditor() {
 
   const measures = useMemo(
     () =>
-      mapMeasureTemplatesToRows({
-        uuid: rootSectionUuid ?? '',
-        descendants: filteredData ?? [],
-      }),
+      mapMeasureTemplatesToRows(
+        {
+          uuid: rootSectionUuid ?? '',
+          descendants: filteredData ?? [],
+        },
+        baselineYear,
+        targetYear
+      ),
     [filteredData, rootSectionUuid]
   );
 

--- a/components/DataCollection.tsx
+++ b/components/DataCollection.tsx
@@ -56,11 +56,19 @@ const DataCollection = ({ measureTemplates }: Props) => {
   };
 
   const dataMeasures = measureTemplates.dataCollection
-    ? mapMeasureTemplatesToRows(measureTemplates.dataCollection)
+    ? mapMeasureTemplatesToRows(
+        measureTemplates.dataCollection,
+        baselineYear ?? null,
+        targetYear ?? null
+      )
     : undefined;
 
   const assumptionMeasures = measureTemplates.futureAssumptions
-    ? mapMeasureTemplatesToRows(measureTemplates.futureAssumptions)
+    ? mapMeasureTemplatesToRows(
+        measureTemplates.futureAssumptions,
+        baselineYear ?? null,
+        targetYear ?? null
+      )
     : undefined;
 
   return (

--- a/queries/get-measure-templates.ts
+++ b/queries/get-measure-templates.ts
@@ -44,6 +44,7 @@ export const GET_MEASURE_TEMPLATES = gql`
     uuid
     priority
     name
+    yearBound
     unit {
       htmlShort
       htmlLong

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -1034,6 +1034,7 @@ export type MeasureTemplate = {
   userPermissions?: Maybe<UserPermissions>;
   userRoles?: Maybe<Array<Scalars['String']['output']>>;
   uuid: Scalars['UUID']['output'];
+  yearBound: Scalars['Boolean']['output'];
 };
 
 
@@ -2368,7 +2369,7 @@ export type GetMeasureTemplatesQuery = (
           { uuid: any }
           & { __typename?: 'Section' }
         ) | null, measureTemplates: Array<(
-          { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, defaultValueSource: string, unit: (
+          { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, yearBound: boolean, defaultValueSource: string, unit: (
             { htmlShort: string, htmlLong: string, short: string, long: string }
             & { __typename?: 'UnitType' }
           ), defaultDataPoints: Array<(
@@ -2392,7 +2393,7 @@ export type GetMeasureTemplatesQuery = (
           { uuid: any }
           & { __typename?: 'Section' }
         ) | null, measureTemplates: Array<(
-          { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, defaultValueSource: string, unit: (
+          { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, yearBound: boolean, defaultValueSource: string, unit: (
             { htmlShort: string, htmlLong: string, short: string, long: string }
             & { __typename?: 'UnitType' }
           ), defaultDataPoints: Array<(
@@ -2425,7 +2426,7 @@ export type MainSectionMeasuresFragment = (
       { uuid: any }
       & { __typename?: 'Section' }
     ) | null, measureTemplates: Array<(
-      { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, defaultValueSource: string, unit: (
+      { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, yearBound: boolean, defaultValueSource: string, unit: (
         { htmlShort: string, htmlLong: string, short: string, long: string }
         & { __typename?: 'UnitType' }
       ), defaultDataPoints: Array<(
@@ -2450,7 +2451,7 @@ export type SectionFragmentFragment = (
     { uuid: any }
     & { __typename?: 'Section' }
   ) | null, measureTemplates: Array<(
-    { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, defaultValueSource: string, unit: (
+    { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, yearBound: boolean, defaultValueSource: string, unit: (
       { htmlShort: string, htmlLong: string, short: string, long: string }
       & { __typename?: 'UnitType' }
     ), defaultDataPoints: Array<(
@@ -2469,7 +2470,7 @@ export type SectionFragmentFragment = (
 );
 
 export type MeasureTemplateFragmentFragment = (
-  { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, defaultValueSource: string, unit: (
+  { id: string, uuid: any, priority: FrameworksMeasureTemplatePriorityChoices, name: string, yearBound: boolean, defaultValueSource: string, unit: (
     { htmlShort: string, htmlLong: string, short: string, long: string }
     & { __typename?: 'UnitType' }
   ), defaultDataPoints: Array<(

--- a/utils/measures.tsx
+++ b/utils/measures.tsx
@@ -53,7 +53,7 @@ function filterYearBoundMeasureTemplate(
     return false;
   }
 
-  return numericName >= baselineYear && numericName <= targetYear;
+  return numericName > baselineYear && numericName <= targetYear;
 }
 
 export function mapMeasureTemplatesToRows(


### PR DESCRIPTION
The "Electrification of buses" measure is a special case that allows the user to enter yearly values on the progress of bus electrification. 

Now that the user can enter a custom target year, we need to dynamically show all yearly inputs up to the target year.

| Before | After
| -- | -- |
| Measures shown for bus electrification start before the baseline year and end after the target year | Measures for bus electrification are between the baseline and target years |
| <img width="1190" alt="image" src="https://github.com/user-attachments/assets/78abbb59-adc3-4769-97ca-c46e9b9e97f7" /> | <img width="1174" alt="image" src="https://github.com/user-attachments/assets/12da3225-4eb1-43a2-979f-fde186a78010" /> |