### PR TITLE
Ensure yearly measures outside of the baseline to target year range are not included in the total priority count

### DIFF
--- a/components/AdditionalDatasheetEditor.tsx
+++ b/components/AdditionalDatasheetEditor.tsx
@@ -493,7 +493,7 @@ export function AdditionalDatasheetEditor() {
         baselineYear,
         targetYear
       ),
-    [filteredData, rootSectionUuid]
+    [filteredData, rootSectionUuid, baselineYear, targetYear]
   );
 
   if (loading) {

--- a/utils/measures.tsx
+++ b/utils/measures.tsx
@@ -33,7 +33,7 @@ const filterMeasureTemplate =
  * We filter these measure templates so that they're between the baseline and target year.
  * This isn't the ideal solution, but we'll revisit this logic on the backend later.
  */
-function filterYearBoundMeasureTemplate(
+export function filterYearBoundMeasureTemplate(
   measureTemplate: MeasureTemplateFragmentFragment,
   baselineYear: number | null,
   targetYear: number | null


### PR DESCRIPTION
Use `filterYearBoundMeasureTemplate` to filter measures out before including them in the priority tally. Bus electrification measures run from 2019 to 2050, however, for example, a plan may have a baseline year of 2020 and a target year of 2030. In that case, only 10 bus electrification measures are shown but previously all 30 were added to the tally.

| Before | After |
| -- | -- |
| <img width="808" alt="Screenshot 2025-01-09 at 10 05 04" src="https://github.com/user-attachments/assets/0ad4d889-886d-4378-884f-6d00b9eca014" /> | <img width="819" alt="Screenshot 2025-01-09 at 10 04 17" src="https://github.com/user-attachments/assets/6358b62e-18a8-46a2-a39f-925d2d88de2c" /> |