### PR TITLE
Add agriculture emissions input to additional historical data page

### DIFF
--- a/constants/measure-overrides.ts
+++ b/constants/measure-overrides.ts
@@ -87,4 +87,7 @@ export const ADDITIONAL_MEASURES = [
   {
     uuid: '58c99d80-8b05-4573-8291-9252560414fd',
   },
+  {
+    uuid: 'a08d4504-a43c-4dc1-ac2d-27d7aef5c241',
+  },
 ];


### PR DESCRIPTION
After evaluating around 40 cities' climate action plans, Agriculture emissions are more important than expected so this lil change adds the input to additional historical data.

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/9326aed4-894e-4707-99d0-60765ef9d58b" />
