### PR TITLE
Fix apollo cache warning for framework configs

### DIFF
--- a/components/providers/ApolloWrapper.tsx
+++ b/components/providers/ApolloWrapper.tsx
@@ -20,6 +20,21 @@ import logger from '@/utils/logger';
 
 const cache = new InMemoryCache({
   typePolicies: {
+    Framework: {
+      fields: {
+        configs: {
+          merge(existing, incoming) {
+            return incoming; // Replace Framework.configs with incoming data since we always fetch full list
+          },
+        },
+        config: {
+          read(_, { args, toReference }) {
+            // Read individual config from configs array
+            return toReference({ __typename: 'FrameworkConfig', id: args?.id });
+          },
+        },
+      },
+    },
     Section: {
       keyFields: ['uuid'],
     },

--- a/queries/framework/create-framework-config.ts
+++ b/queries/framework/create-framework-config.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client';
+import { FrameworkConfigFragment } from './get-framework-config';
 
 export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
   mutation CreateNZCFramework(
@@ -27,25 +28,17 @@ export const CREATE_NZC_FRAMEWORK_CONFIG = gql`
     ) {
       ok
       frameworkConfig {
-        id
-        organizationName
-        baselineYear
-        targetYear
-        viewUrl
-        resultsDownloadUrl
+        ...FrameworkConfig
         # Return the updated full list of framework configs to automatically update the cache
         framework {
           id
           configs {
-            id
-            viewUrl
-            resultsDownloadUrl
-            organizationName
-            baselineYear
-            targetYear
+            ...FrameworkConfig
           }
         }
       }
     }
   }
+
+  ${FrameworkConfigFragment}
 `;

--- a/queries/framework/get-framework-config.ts
+++ b/queries/framework/get-framework-config.ts
@@ -1,18 +1,13 @@
 import { gql } from '@apollo/client';
 
-export const GET_FRAMEWORK_CONFIG = gql`
-  query GetFrameworkConfig($id: ID!) {
-    framework(identifier: "nzc") {
-      id
-      config(id: $id) {
-        id
-        organizationName
-        baselineYear
-        targetYear
-        viewUrl
-        resultsDownloadUrl
-      }
-    }
+export const FrameworkConfigFragment = gql`
+  fragment FrameworkConfig on FrameworkConfig {
+    id
+    organizationName
+    baselineYear
+    targetYear
+    viewUrl
+    resultsDownloadUrl
   }
 `;
 
@@ -21,13 +16,10 @@ export const GET_FRAMEWORK_CONFIGS = gql`
     framework(identifier: "nzc") {
       id
       configs {
-        id
-        organizationName
-        baselineYear
-        targetYear
-        viewUrl
-        resultsDownloadUrl
+        ...FrameworkConfig
       }
     }
   }
+
+  ${FrameworkConfigFragment}
 `;

--- a/types/__generated__/graphql.ts
+++ b/types/__generated__/graphql.ts
@@ -2224,7 +2224,9 @@ export type UpdateMeasuresMutation = (
   & { __typename?: 'Mutations' }
 );
 
-export type ProfileQueryVariables = Exact<{ [key: string]: never; }>;
+export type ProfileQueryVariables = Exact<{
+  selectedPlanId: Scalars['ID']['input'];
+}>;
 
 
 export type ProfileQuery = (
@@ -2238,13 +2240,13 @@ export type ProfileQuery = (
     { id: string, userRoles?: Array<string> | null, userPermissions?: (
       { change: boolean, creatableRelatedModels: Array<string | null> }
       & { __typename?: 'UserPermissions' }
-    ) | null, configs: Array<(
-      { id: string, userPermissions?: (
+    ) | null, config?: (
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, userPermissions?: (
         { view: boolean, change: boolean, delete: boolean, actions: Array<ModelAction | null>, creatableRelatedModels: Array<string | null>, otherPermissions: Array<string | null> }
         & { __typename?: 'UserPermissions' }
       ) | null }
-      & { __typename: 'FrameworkConfig' }
-    )> }
+      & { __typename?: 'FrameworkConfig' }
+    ) | null }
     & { __typename?: 'Framework' }
   ) | null }
   & { __typename?: 'Query' }
@@ -2267,7 +2269,7 @@ export type CreateNzcFrameworkMutation = (
     { ok: boolean, frameworkConfig?: (
       { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, framework: (
         { id: string, configs: Array<(
-          { id: string, viewUrl?: string | null, resultsDownloadUrl?: string | null, organizationName?: string | null, baselineYear: number, targetYear?: number | null }
+          { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
           & { __typename?: 'FrameworkConfig' }
         )> }
         & { __typename?: 'Framework' }
@@ -2292,20 +2294,9 @@ export type DeleteFrameworkMutation = (
   & { __typename?: 'Mutations' }
 );
 
-export type GetFrameworkConfigQueryVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
-
-
-export type GetFrameworkConfigQuery = (
-  { framework?: (
-    { id: string, config?: (
-      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
-      & { __typename?: 'FrameworkConfig' }
-    ) | null }
-    & { __typename?: 'Framework' }
-  ) | null }
-  & { __typename?: 'Query' }
+export type FrameworkConfigFragment = (
+  { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
+  & { __typename?: 'FrameworkConfig' }
 );
 
 export type GetFrameworkConfigsQueryVariables = Exact<{ [key: string]: never; }>;


### PR DESCRIPTION
## Problem
Apollo is showing a cache warning in production when updating Framework configs:
> ⚠️ Cache data may be lost when replacing the configs field of a Framework object.

This occurs because Apollo doesn't know how to safely merge the `configs` array field when updates occur, potentially causing unnecessary network requests.

## Solution
Added a merge function in the Apollo cache configuration to explicitly handle updates to the Framework's `configs` field. Since our queries always return the complete list of configs, we can just replace the existing data with incoming data.

Also added a GQL fragment for `FrameworkConfig` queries.