### PR TITLE
Update import export logic to include non-baseline year data

### DIFF
--- a/src/components/SnackbarProvider.tsx
+++ b/src/components/SnackbarProvider.tsx
@@ -12,7 +12,7 @@ import { Alert, AlertTitle, Snackbar } from '@mui/material';
  *          snackbars in future.
  */
 
-type Notification = {
+export type Notification = {
   message: ReactNode;
   extraDetails?: ReactNode;
   severity: AlertProps['severity'];

--- a/src/queries/get-measures.ts
+++ b/src/queries/get-measures.ts
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+
+const MEASURE_FRAGMENT = gql`
+  fragment MeasureFragment on Measure {
+    id
+    internalNotes
+    measureTemplate {
+      uuid
+    }
+    dataPoints {
+      value
+      year
+    }
+  }
+`;
+
+export const GET_MEASURES = gql`
+  query GetMeasures($id: ID!) {
+    framework(identifier: "nzc") {
+      config(id: $id) {
+        measures {
+          ...MeasureFragment
+        }
+      }
+    }
+  }
+
+  ${MEASURE_FRAGMENT}
+`;

--- a/src/types/__generated__/graphql.ts
+++ b/src/types/__generated__/graphql.ts
@@ -2588,6 +2588,42 @@ export type MeasureTemplateFragmentFragment = (
   & { __typename?: 'MeasureTemplate' }
 );
 
+export type MeasureFragmentFragment = (
+  { id: string, internalNotes: string, measureTemplate: (
+    { uuid: any }
+    & { __typename?: 'MeasureTemplate' }
+  ), dataPoints: Array<(
+    { value?: number | null, year: number }
+    & { __typename?: 'MeasureDataPoint' }
+  )> }
+  & { __typename?: 'Measure' }
+);
+
+export type GetMeasuresQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type GetMeasuresQuery = (
+  { framework?: (
+    { config?: (
+      { measures: Array<(
+        { id: string, internalNotes: string, measureTemplate: (
+          { uuid: any }
+          & { __typename?: 'MeasureTemplate' }
+        ), dataPoints: Array<(
+          { value?: number | null, year: number }
+          & { __typename?: 'MeasureDataPoint' }
+        )> }
+        & { __typename?: 'Measure' }
+      )> }
+      & { __typename?: 'FrameworkConfig' }
+    ) | null }
+    & { __typename?: 'Framework' }
+  ) | null }
+  & { __typename?: 'Query' }
+);
+
 export type DataPointFragmentFragment = (
   { id: string, value?: number | null, year: number, defaultValue?: number | null }
   & { __typename: 'MeasureDataPoint' }


### PR DESCRIPTION
- Update the export/ import logic to include all data (not just for the baseline year) in exports.
- Ensures legacy files (`version: 1`) that have been exported can still be imported.
- Fetches the full list of fresh measures upon opening the import modal, rather than recursively finding measures via sections as previously.

<img width="726" alt="image" src="https://github.com/user-attachments/assets/29c8282f-e0ce-4498-92e1-1d84c647966d" />