### PR TITLE
Remove low priority data point classification

### DIFF
--- a/src/components/PriorityBadge.tsx
+++ b/src/components/PriorityBadge.tsx
@@ -1,14 +1,13 @@
-import { FrameworksMeasureTemplatePriorityChoices as Priority } from '@/types/__generated__/graphql';
 import { Stack, Tooltip, Typography } from '@mui/material';
-import type {
-  IconProps} from 'react-bootstrap-icons';
+import type { IconProps } from 'react-bootstrap-icons';
 import {
-  Icon3CircleFill as LowPriorityIcon,
+  Icon1CircleFill as HighPriorityIcon,
   Icon2CircleFill as MedPriorityIcon,
-  Icon1CircleFill as HighPriorityIcon
 } from 'react-bootstrap-icons';
 
-export const PRIORITY_TYPES = [Priority.High, Priority.Medium, Priority.Low];
+import { FrameworksMeasureTemplatePriorityChoices as Priority } from '@/types/__generated__/graphql';
+
+export const PRIORITY_TYPES = [Priority.High, Priority.Medium];
 
 interface PriorityIconProps extends IconProps {
   priorityType: Priority;
@@ -17,8 +16,6 @@ interface PriorityIconProps extends IconProps {
 export const PriorityIcon = ({ priorityType, ...rest }: PriorityIconProps) => {
   // TODO: Move these colours to the theme
   switch (priorityType) {
-    case Priority.Low:
-      return <LowPriorityIcon color={'#48cae4'} {...rest} />;
     case Priority.Medium:
       return <MedPriorityIcon color={'#00b4d8'} {...rest} />;
     case Priority.High:
@@ -46,8 +43,6 @@ type PriorityBadgeProps = BadgePriorityBadgeProps | CountPriorityBadgeProps;
 
 export function getPriorityLabel(priority: Priority) {
   switch (priority) {
-    case Priority.Low:
-      return 'Low';
     case Priority.Medium:
       return 'Moderate';
     case Priority.High:
@@ -57,11 +52,7 @@ export function getPriorityLabel(priority: Priority) {
   }
 }
 
-export function PriorityBadge({
-  variant = 'count',
-  priority,
-  ...rest
-}: PriorityBadgeProps) {
+export function PriorityBadge({ variant = 'count', priority, ...rest }: PriorityBadgeProps) {
   if (variant === 'badge') {
     return (
       <Stack spacing={1} direction="row" alignItems="center">

--- a/src/components/SupportModal.tsx
+++ b/src/components/SupportModal.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
+
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Typography,
-  Button,
-  Stack,
-  IconButton,
   Accordion,
-  AccordionSummary,
   AccordionDetails,
+  AccordionSummary,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
   Link,
+  Stack,
+  Typography,
 } from '@mui/material';
 import { ChevronDown, X } from 'react-bootstrap-icons';
+
 import { FAQS as OtherFAQS } from '@/constants/faqs';
 
 interface SupportModalProps {
@@ -38,9 +40,9 @@ const FAQS = [
       'The "Baseline Year" serves as the reference point from which all emissions reduction efforts are measured. It is the starting year against which progress towards achieving climate targets is assessed. By selecting a baseline year, you establish a consistent benchmark to track changes in emissions over time, enabling accurate comparisons and evaluations of your city\'s efforts to reach net-zero emissions. This helps in understanding the impact of implemented actions and in planning future strategies effectively.',
   },
   {
-    title: 'What do the priority levels (High, Moderate, Low) mean?',
+    title: 'What do the priority levels (High, Moderate) mean?',
     description:
-      'Priority levels indicate the importance of providing data for different measures in NetZeroPlanner. High priority measures are crucial for tracking and achieving climate goals, requiring essential data inputs. Moderate priority measures are important but not critical, enhancing the overall understanding of progress. Low priority measures are less critical and providing data for them is helpful but not essential for the primary evaluation of climate action progress.',
+      'Priority levels indicate the importance of providing data for different measures in NetZeroPlanner. High priority measures are crucial for tracking and achieving climate goals, requiring essential data inputs. Moderate priority measures are important but not critical, enhancing the overall understanding of progress.',
   },
   ...OtherFAQS,
 ];
@@ -65,10 +67,9 @@ const SupportModal = ({ open, onClose }: SupportModalProps) => {
           NetZeroPlanner support
         </Typography>
         <Typography paragraph>
-          Welcome to NetZeroPlanner! Here you can find answers to common
-          questions and get the help you need to make the most of our tool. If
-          you can't find what you're looking for, please contact our team at{' '}
-          <Link href="mailto:support@kausal.tech">support@kausal.tech</Link> for
+          Welcome to NetZeroPlanner! Here you can find answers to common questions and get the help
+          you need to make the most of our tool. If you can't find what you're looking for, please
+          contact our team at <Link href="mailto:support@kausal.tech">support@kausal.tech</Link> for
           further assistance.
         </Typography>
         <Stack spacing={2} alignItems="flex-start">
@@ -78,18 +79,13 @@ const SupportModal = ({ open, onClose }: SupportModalProps) => {
             </Typography>
             {FAQS.map((faq) => (
               <Accordion disableGutters key={faq.title}>
-                <AccordionSummary
-                  sx={{ pl: 0 }}
-                  expandIcon={<ChevronDown size={20} />}
-                >
+                <AccordionSummary sx={{ pl: 0 }} expandIcon={<ChevronDown size={20} />}>
                   <Typography color="primary.main" variant="subtitle2">
                     {faq.title}
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <Typography color="text.secondary">
-                    {faq.description}
-                  </Typography>
+                  <Typography color="text.secondary">{faq.description}</Typography>
                 </AccordionDetails>
               </Accordion>
             ))}

--- a/src/constants/faqs.tsx
+++ b/src/constants/faqs.tsx
@@ -2,42 +2,37 @@ import { Link } from '@mui/material';
 
 export const FAQS = [
   {
-    title:
-      'What is the purpose of an economic case, and what value does it have for me?',
+    title: 'What is the purpose of an economic case, and what value does it have for me?',
     description: (
       <ul>
         <li>
-          The economic case allows cities to analyze the costs and benefits of
-          the Actions in their Climate Action Plan to maximize decarbonization
-          benefits for Euros invested.
+          The economic case allows cities to analyze the costs and benefits of the Actions in their
+          Climate Action Plan to maximize decarbonization benefits for Euros invested.
         </li>
 
         <li>
-          The NetZeroPlanner model breaks down the decarbonization impacts along
-          with the costs and benefits of the Climate Action Plan by sub-sector
-          and stakeholder group to allow for assessment and prioritization of
-          projects so that limited city budgets can be directed to projects with
-          the highest monetary and carbon Return on Investment (ROI).
+          The NetZeroPlanner model breaks down the decarbonization impacts along with the costs and
+          benefits of the Climate Action Plan by sub-sector and stakeholder group to allow for
+          assessment and prioritization of projects so that limited city budgets can be directed to
+          projects with the highest monetary and carbon Return on Investment (ROI).
         </li>
 
         <li>
-          Calculating ROI including co-benefits helps to make the case to city
-          leaders for allocations of limited budget resources to decarbonization
-          projects. It can also help citizens and businesses better understand
-          the positive returns they can expect from the investments they will
-          need to make to decarbonize.
+          Calculating ROI including co-benefits helps to make the case to city leaders for
+          allocations of limited budget resources to decarbonization projects. It can also help
+          citizens and businesses better understand the positive returns they can expect from the
+          investments they will need to make to decarbonize.
         </li>
 
         <li>
-          The economic case provides high level backup to support any
-          incremental financing that might be necessary to fill budget
-          shortfalls.
+          The economic case provides high level backup to support any incremental financing that
+          might be necessary to fill budget shortfalls.
         </li>
 
         <li>
-          It can also serve to bridge the communication gap between city climate
-          teams and city finance departments so they can work together to make
-          sure the Climate Action Plan is properly funded and implemented.
+          It can also serve to bridge the communication gap between city climate teams and city
+          finance departments so they can work together to make sure the Climate Action Plan is
+          properly funded and implemented.
         </li>
       </ul>
     ),
@@ -86,9 +81,9 @@ export const FAQS = [
       'How does the model handle co-benefits and where can I find additional information on the research that backs up the model methodology?',
     description: (
       <>
-        The model monetizes the co-benefits related to Health and includes those
-        benefits in the cost / benefit analysis. Additional information on
-        co-benefits can be found on the NetZeroCities portal at:
+        The model monetizes the co-benefits related to Health and includes those benefits in the
+        cost / benefit analysis. Additional information on co-benefits can be found on the
+        NetZeroCities portal at:
         <Link
           rel="noopener noreferrer"
           target="_blank"
@@ -118,7 +113,7 @@ export const FAQS = [
     title:
       'Do I have to fill in every one of the fields in the Data Collection and Future Assumptions tabs?  What if I am missing data for some of those fields? ',
     description:
-      'You do not have to fill in every input field. All fields include a Comparable City Value that is based on an average of European cities that are similar to yours.  If you do not input a number in any field, the system will default to the Comparable City Value.  The Comparable City Value can also be used to validate the inputs you do have.  If you decide to use the Comparable City Value, please be sure to review the number to ensure that it well represents your city.  All input fields are also marked as High, Moderate, or Low priority to make it easier for you to know which fields to focus on, and which ones where you might decide to just use the Comparable City Value.',
+      'You do not have to fill in every input field. All fields include a Comparable City Value that is based on an average of European cities that are similar to yours.  If you do not input a number in any field, the system will default to the Comparable City Value.  The Comparable City Value can also be used to validate the inputs you do have.  If you decide to use the Comparable City Value, please be sure to review the number to ensure that it well represents your city.  All input fields are also marked as High or Moderate priority to make it easier for you to know which fields to focus on, and which ones where you might decide to just use the Comparable City Value.',
   },
 
   {
@@ -137,8 +132,7 @@ export const FAQS = [
 
   {
     title: 'How should I handle carbon sinks such as forestation in the model?',
-    description:
-      'The model does not calculate the carbon benefits of carbon sinks. ',
+    description: 'The model does not calculate the carbon benefits of carbon sinks. ',
   },
 
   {
@@ -161,19 +155,17 @@ export const FAQS = [
     description: (
       <ul>
         <li>
-          One of the main reasons the numbers will likely not match is because
-          the model calculates Incremental Cost, while your city likely budgets
-          Total Cost. As an example, the model only includes the additional cost
-          of an electric bus over an above the cost of a replacement diesel bus.
-          Since your budget likely includes the total cost of the electric bus,
-          your budget may be higher than what the model shows.
+          One of the main reasons the numbers will likely not match is because the model calculates
+          Incremental Cost, while your city likely budgets Total Cost. As an example, the model only
+          includes the additional cost of an electric bus over an above the cost of a replacement
+          diesel bus. Since your budget likely includes the total cost of the electric bus, your
+          budget may be higher than what the model shows.
         </li>
         <li>
-          Another reason is that the model only includes the Direct Cost of each
-          sub-sector or lever, not the Indirect Cost. In our bus example, it
-          would calculate the incremental cost of the electric bus plus charging
-          infrastructure, but it would not include the cost of a dedicated bus
-          lane for those electric buses.
+          Another reason is that the model only includes the Direct Cost of each sub-sector or
+          lever, not the Indirect Cost. In our bus example, it would calculate the incremental cost
+          of the electric bus plus charging infrastructure, but it would not include the cost of a
+          dedicated bus lane for those electric buses.
         </li>
       </ul>
     ),

--- a/src/utils/csv-import/__mocks__/data-request-parsed-result.ts
+++ b/src/utils/csv-import/__mocks__/data-request-parsed-result.ts
@@ -2,11 +2,8 @@
  * The expected output based on receiving data-request.csv.ts as an input. If the structure
  * of the csv parsing output changes, generate a new output and copy it here.
  */
-export const EXPECTED_MEASURES = new Map([
-  [
-    '3779efa4-9eb0-4f4b-b5d5-eb510461bed8',
-    { label: 'Population', value: 820000, comment: '' },
-  ],
+const ALL_MEASURES = new Map([
+  ['3779efa4-9eb0-4f4b-b5d5-eb510461bed8', { label: 'Population', value: 820000, comment: '' }],
   [
     'ef124e9e-51a3-4cf1-99f2-7f925ab253e0',
     {
@@ -15,10 +12,7 @@ export const EXPECTED_MEASURES = new Map([
       comment: '',
     },
   ],
-  [
-    '63f11aa5-f09c-4f54-a2c0-65738680ffdd',
-    { label: 'City Area', value: 139, comment: '' },
-  ],
+  ['63f11aa5-f09c-4f54-a2c0-65738680ffdd', { label: 'City Area', value: 139, comment: '' }],
   [
     'c3f157c0-ae56-470f-9ac7-e7ac0080626d',
     {
@@ -55,38 +49,14 @@ export const EXPECTED_MEASURES = new Map([
     '1869b124-b2c4-4ce2-b7ca-dc477b957bbb',
     { label: 'Average passengers per metro train', value: 40, comment: '' },
   ],
-  [
-    'e7b12aeb-e591-4cba-96e7-9901fb95d0fb',
-    { label: 'CO2e emissions', value: 130, comment: '' },
-  ],
-  [
-    '1a328799-4774-4901-be1f-e6b46fb84ef7',
-    { label: 'NOx emissions', value: 0.61, comment: '' },
-  ],
-  [
-    '8e9c2502-128f-4368-ad09-debb8d2e06c8',
-    { label: 'PM 2.5 emissions', value: 0.02, comment: '' },
-  ],
-  [
-    'ac14daee-a60e-445a-b56b-bc0600e9788d',
-    { label: 'PM 10 emissions', value: 0.03, comment: '' },
-  ],
-  [
-    'e2f0c38d-5b98-4634-8faf-ea07caae26a5',
-    { label: 'CO2e emissions', value: 800, comment: '' },
-  ],
-  [
-    '80414475-5306-4e66-8ff9-c15f346c61fe',
-    { label: 'NOx emissions', value: 3.22, comment: '' },
-  ],
-  [
-    '56ad8ce0-a583-4011-846d-ad44cbc92052',
-    { label: 'PM 2.5 emissions', value: 0.07, comment: '' },
-  ],
-  [
-    '5c1b815c-6c13-4303-b9ff-f641cd725c4e',
-    { label: 'PM 10 emissions', value: 0.1, comment: '' },
-  ],
+  ['e7b12aeb-e591-4cba-96e7-9901fb95d0fb', { label: 'CO2e emissions', value: 130, comment: '' }],
+  ['1a328799-4774-4901-be1f-e6b46fb84ef7', { label: 'NOx emissions', value: 0.61, comment: '' }],
+  ['8e9c2502-128f-4368-ad09-debb8d2e06c8', { label: 'PM 2.5 emissions', value: 0.02, comment: '' }],
+  ['ac14daee-a60e-445a-b56b-bc0600e9788d', { label: 'PM 10 emissions', value: 0.03, comment: '' }],
+  ['e2f0c38d-5b98-4634-8faf-ea07caae26a5', { label: 'CO2e emissions', value: 800, comment: '' }],
+  ['80414475-5306-4e66-8ff9-c15f346c61fe', { label: 'NOx emissions', value: 3.22, comment: '' }],
+  ['56ad8ce0-a583-4011-846d-ad44cbc92052', { label: 'PM 2.5 emissions', value: 0.07, comment: '' }],
+  ['5c1b815c-6c13-4303-b9ff-f641cd725c4e', { label: 'PM 10 emissions', value: 0.1, comment: '' }],
   [
     'b8cb403d-e12e-4c79-be6c-ff2fd7c0016b',
     {
@@ -118,8 +88,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '8a0ddf12-611d-45c0-b51b-c5722f5fb88c',
     {
-      label:
-        'Share of bus fleet as fully electric buses (not including hybrids)',
+      label: 'Share of bus fleet as fully electric buses (not including hybrids)',
       value: 0,
       comment: '',
     },
@@ -144,38 +113,13 @@ export const EXPECTED_MEASURES = new Map([
     '8a8b40eb-1848-48cd-9f61-0043ff158d7a',
     { label: 'Heavy duty trucks >3.5 tonnes', value: 45, comment: '' },
   ],
-  [
-    'f431fe40-d06f-4cc3-8d33-d4ee116105db',
-    { label: 'CO2e emissions', value: 216, comment: '' },
-  ],
-  [
-    '51626bc7-17ca-4086-bca8-6ad806bbc224',
-    { label: 'NOx emissions', value: 0.68, comment: '' },
-  ],
-  [
-    '11d16a62-2f77-437c-b586-3a86586edac6',
-    { label: 'PM 2.5 emissions', value: 0.04, comment: '' },
-  ],
-  [
-    '46fdb8f7-3125-4689-be93-7b1c03abf98c',
-    { label: 'PM 10 emissions', value: 0.05, comment: '' },
-  ],
-  [
-    'df758173-b169-46d5-b859-94f67ea0c20b',
-    { label: 'CO2e emissions', value: 374, comment: '' },
-  ],
-  [
-    '00005eaf-8435-4048-8950-ae010dc6ee5e',
-    { label: 'NOx emissions', value: 1.61, comment: '' },
-  ],
-  [
-    '6be10a46-8b31-46a5-a454-42b30d7f3e6f',
-    { label: 'PM 2.5 emissions', value: 0.05, comment: '' },
-  ],
-  [
-    'fd2e2ed0-26de-4ca4-afa5-889e6cceb9fa',
-    { label: 'PM 10 emissions', value: 0.07, comment: '' },
-  ],
+  ['f431fe40-d06f-4cc3-8d33-d4ee116105db', { label: 'CO2e emissions', value: 216, comment: '' }],
+  ['51626bc7-17ca-4086-bca8-6ad806bbc224', { label: 'NOx emissions', value: 0.68, comment: '' }],
+  ['11d16a62-2f77-437c-b586-3a86586edac6', { label: 'PM 2.5 emissions', value: 0.04, comment: '' }],
+  ['46fdb8f7-3125-4689-be93-7b1c03abf98c', { label: 'PM 10 emissions', value: 0.05, comment: '' }],
+  ['df758173-b169-46d5-b859-94f67ea0c20b', { label: 'CO2e emissions', value: 374, comment: '' }],
+  ['6be10a46-8b31-46a5-a454-42b30d7f3e6f', { label: 'PM 2.5 emissions', value: 0.05, comment: '' }],
+  ['fd2e2ed0-26de-4ca4-afa5-889e6cceb9fa', { label: 'PM 10 emissions', value: 0.07, comment: '' }],
   [
     '3ec0915e-acc1-4fa4-b728-ee3c5051714f',
     { label: 'Light duty trucks <3.5 tonnes', value: 17641, comment: '' },
@@ -203,8 +147,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '70c95faa-24d8-490f-9eac-b9423a6bf155',
     {
-      label:
-        'Average heat use in existing buildings (space heating + domestic hot water)',
+      label: 'Average heat use in existing buildings (space heating + domestic hot water)',
       value: 140,
       comment: '',
     },
@@ -248,8 +191,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '27fedd37-18bd-4ece-8831-e96993c592d6',
     {
-      label:
-        'Share of new buildings built with "better than minimum" standard (today)',
+      label: 'Share of new buildings built with "better than minimum" standard (today)',
       value: 0,
       comment: '',
     },
@@ -257,8 +199,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '0ae5fb06-48a4-4774-9799-ccfa4e8f44a5',
     {
-      label:
-        'Total heating demand (space heating + domestic hot water + heat for cooking)',
+      label: 'Total heating demand (space heating + domestic hot water + heat for cooking)',
       value: 1630,
       comment: '',
     },
@@ -274,8 +215,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '3b58ecda-77bb-4ac6-80bf-7f802442bbb4',
     {
-      label:
-        'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
+      label: 'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
       value: 60,
       comment: '',
     },
@@ -292,19 +232,12 @@ export const EXPECTED_MEASURES = new Map([
     '612e6a3c-81fa-4af2-9c04-18ef39778b91',
     { label: 'Waste (fossil & non-fossil waste)', value: 0, comment: '' },
   ],
-  [
-    '26a0df38-6711-4590-9283-aa519dfa4e45',
-    { label: 'Fossil share', value: 30, comment: '' },
-  ],
-  [
-    'd926a4e8-e8a4-4f8e-848b-1bee6092cd38',
-    { label: 'Non-fossil share', value: 70, comment: '' },
-  ],
+  ['26a0df38-6711-4590-9283-aa519dfa4e45', { label: 'Fossil share', value: 30, comment: '' }],
+  ['d926a4e8-e8a4-4f8e-848b-1bee6092cd38', { label: 'Non-fossil share', value: 70, comment: '' }],
   [
     '16e07a92-6437-4eb2-bc6e-8dc0de375dcd',
     {
-      label:
-        'Fossil (oil, gas, coal) + inefficient electric heating (not heat pumps)',
+      label: 'Fossil (oil, gas, coal) + inefficient electric heating (not heat pumps)',
       value: 70,
       comment: '',
     },
@@ -317,38 +250,17 @@ export const EXPECTED_MEASURES = new Map([
     'c8091681-cc83-416c-b4d2-7965b441e94e',
     { label: 'Biobased / solar water heating', value: 0, comment: '' },
   ],
-  [
-    'd178d6ca-ac4b-4e6f-871f-9a79555cb2de',
-    { label: 'CO2e emissions', value: 200, comment: '' },
-  ],
-  [
-    'fae64934-4d43-4b58-9ee4-9f7b37cd7335',
-    { label: 'NOx emissions', value: 0.139, comment: '' },
-  ],
+  ['d178d6ca-ac4b-4e6f-871f-9a79555cb2de', { label: 'CO2e emissions', value: 200, comment: '' }],
+  ['fae64934-4d43-4b58-9ee4-9f7b37cd7335', { label: 'NOx emissions', value: 0.139, comment: '' }],
   [
     '501d46fa-6d86-422f-a818-b712612995c4',
     { label: 'PM 2.5 emissions', value: 0.003, comment: '' },
   ],
-  [
-    'f8d3b736-1fe9-49ce-851b-d881f11d8a89',
-    { label: 'PM 10 emissions', value: 0.005, comment: '' },
-  ],
-  [
-    '8b5c3adb-307c-4bd1-8b9f-1d6e01c34c50',
-    { label: 'CO2e emissions', value: 213, comment: '' },
-  ],
-  [
-    '00924063-1dd8-43b1-a118-f3e29edbecf7',
-    { label: 'NOx emissions', value: 0.24, comment: '' },
-  ],
-  [
-    '22dcb86a-4523-466d-be25-8b2fe4a58c20',
-    { label: 'PM 2.5 emissions', value: 0.02, comment: '' },
-  ],
-  [
-    'e1069a45-21db-4210-96a3-71210c7a9cf8',
-    { label: 'PM 10 emissions', value: 0.03, comment: '' },
-  ],
+  ['f8d3b736-1fe9-49ce-851b-d881f11d8a89', { label: 'PM 10 emissions', value: 0.005, comment: '' }],
+  ['8b5c3adb-307c-4bd1-8b9f-1d6e01c34c50', { label: 'CO2e emissions', value: 213, comment: '' }],
+  ['00924063-1dd8-43b1-a118-f3e29edbecf7', { label: 'NOx emissions', value: 0.24, comment: '' }],
+  ['22dcb86a-4523-466d-be25-8b2fe4a58c20', { label: 'PM 2.5 emissions', value: 0.02, comment: '' }],
+  ['e1069a45-21db-4210-96a3-71210c7a9cf8', { label: 'PM 10 emissions', value: 0.03, comment: '' }],
   [
     '5f7c8175-d3ae-4e05-9179-325b84934ead',
     {
@@ -357,34 +269,16 @@ export const EXPECTED_MEASURES = new Map([
       comment: '',
     },
   ],
-  [
-    'b132697d-6a72-476c-aed5-d3fa3886d943',
-    { label: 'Renewable sources', value: 37, comment: '' },
-  ],
-  [
-    '82c7d588-6369-4db8-b961-c83a93d1ae42',
-    { label: 'Fossil sources', value: 41, comment: '' },
-  ],
+  ['b132697d-6a72-476c-aed5-d3fa3886d943', { label: 'Renewable sources', value: 37, comment: '' }],
+  ['82c7d588-6369-4db8-b961-c83a93d1ae42', { label: 'Fossil sources', value: 41, comment: '' }],
   [
     '9bebc7be-cc99-4edb-9932-a4465baa4748',
     { label: 'Other (e.g. nuclear)', value: 22, comment: '' },
   ],
-  [
-    'c549ff9f-91d0-48d8-b1f2-c014eaca748b',
-    { label: 'CO2e emissions', value: 222, comment: '' },
-  ],
-  [
-    '7165c4b8-76a9-4d8a-b437-55f6099dd1ac',
-    { label: 'NOx emissions', value: 0.14, comment: '' },
-  ],
-  [
-    '22545669-4941-445a-bac5-290acf43b110',
-    { label: 'PM 2.5 emissions', value: 0, comment: '' },
-  ],
-  [
-    '93b7feab-da6a-4f33-8726-2ca7c96046b6',
-    { label: 'PM 10 emissions', value: 0.01, comment: '' },
-  ],
+  ['c549ff9f-91d0-48d8-b1f2-c014eaca748b', { label: 'CO2e emissions', value: 222, comment: '' }],
+  ['7165c4b8-76a9-4d8a-b437-55f6099dd1ac', { label: 'NOx emissions', value: 0.14, comment: '' }],
+  ['22545669-4941-445a-bac5-290acf43b110', { label: 'PM 2.5 emissions', value: 0, comment: '' }],
+  ['93b7feab-da6a-4f33-8726-2ca7c96046b6', { label: 'PM 10 emissions', value: 0.01, comment: '' }],
   [
     'd7cbcdbd-9e5a-415e-a37a-5c3eefa26982',
     { label: 'Spot price electricity', value: 50, comment: '' },
@@ -409,22 +303,10 @@ export const EXPECTED_MEASURES = new Map([
     '372c2783-4bf1-413c-b1b3-6f3565502b7e',
     { label: 'Paper and cardboard', value: 68669, comment: '' },
   ],
-  [
-    '4936856c-18bc-4169-b313-cbc41eb36d2a',
-    { label: 'Metal', value: 13965, comment: '' },
-  ],
-  [
-    '095a8cf9-3b6b-4354-af80-6c66daf69a07',
-    { label: 'Plastics', value: 56773, comment: '' },
-  ],
-  [
-    '961df23f-bf66-4091-81f6-b0dd106843a9',
-    { label: 'Glass', value: 28835, comment: '' },
-  ],
-  [
-    '43507336-9c1a-4f27-bbd8-67dec958a11e',
-    { label: 'Organic waste', value: 139462, comment: '' },
-  ],
+  ['4936856c-18bc-4169-b313-cbc41eb36d2a', { label: 'Metal', value: 13965, comment: '' }],
+  ['095a8cf9-3b6b-4354-af80-6c66daf69a07', { label: 'Plastics', value: 56773, comment: '' }],
+  ['961df23f-bf66-4091-81f6-b0dd106843a9', { label: 'Glass', value: 28835, comment: '' }],
+  ['43507336-9c1a-4f27-bbd8-67dec958a11e', { label: 'Organic waste', value: 139462, comment: '' }],
   [
     '30b8f580-389a-4b1d-9f7f-34bf9bdfb0eb',
     {
@@ -533,22 +415,10 @@ export const EXPECTED_MEASURES = new Map([
     '109924c8-95c6-458d-b97b-6a872569dd41',
     { label: 'Share of "other" waste - recycled', value: 10, comment: '' },
   ],
-  [
-    '2c0c3a96-5f4b-4ce1-8e2d-8e6637d611ff',
-    { label: 'CO2e emissions', value: 633, comment: '' },
-  ],
-  [
-    'f9721db6-29dc-4a14-abb9-1cd644d05b39',
-    { label: 'NOx emissions', value: 0.53, comment: '' },
-  ],
-  [
-    '2fe95f5c-5895-4239-a3f9-64425da2e6e4',
-    { label: 'PM 2.5 emissions', value: 0, comment: '' },
-  ],
-  [
-    '90fb1c6f-d882-4995-96bf-d2e190c406e4',
-    { label: 'PM 10 emissions', value: 0, comment: '' },
-  ],
+  ['2c0c3a96-5f4b-4ce1-8e2d-8e6637d611ff', { label: 'CO2e emissions', value: 633, comment: '' }],
+  ['f9721db6-29dc-4a14-abb9-1cd644d05b39', { label: 'NOx emissions', value: 0.53, comment: '' }],
+  ['2fe95f5c-5895-4239-a3f9-64425da2e6e4', { label: 'PM 2.5 emissions', value: 0, comment: '' }],
+  ['90fb1c6f-d882-4995-96bf-d2e190c406e4', { label: 'PM 10 emissions', value: 0, comment: '' }],
   [
     '0bfef6a2-7d17-4cc7-8524-fd429cb9c4bf',
     { label: 'Retail price of electricity', value: 0.28, comment: '' },
@@ -569,10 +439,7 @@ export const EXPECTED_MEASURES = new Map([
     '5475fc15-9236-4720-ab4f-7a21406e4185',
     { label: 'Heavy duty trucks >3.5 tonne', value: 33, comment: '' },
   ],
-  [
-    '452ff8d0-2cd2-4402-9d3d-97035f6eb6ef',
-    { label: 'Buses', value: 49, comment: '' },
-  ],
+  ['452ff8d0-2cd2-4402-9d3d-97035f6eb6ef', { label: 'Buses', value: 49, comment: '' }],
   [
     'c6c0e008-9003-47f6-8579-0e44673374ac',
     { label: 'Other motorized transport', value: 13, comment: '' },
@@ -581,22 +448,13 @@ export const EXPECTED_MEASURES = new Map([
     '913568b2-cdea-4016-be6d-9a3ba8e85dac',
     { label: 'Heating & hot water', value: 193, comment: '' },
   ],
-  [
-    '4f2a53a1-17e1-4625-b302-e4559811ec7f',
-    { label: 'Cooling', value: 0, comment: '' },
-  ],
+  ['4f2a53a1-17e1-4625-b302-e4559811ec7f', { label: 'Cooling', value: 0, comment: '' }],
   [
     '34cc7425-8d60-4e2c-918a-2b7fdd96b1ee',
     { label: 'Other building-related emissions', value: 0, comment: '' },
   ],
-  [
-    'ca614bd8-e4db-4f60-a708-b04d79731f89',
-    { label: 'Buildings', value: 474, comment: '' },
-  ],
-  [
-    '6ea103a2-c602-4da4-88b1-3b134016bbdc',
-    { label: 'Other', value: 0, comment: '' },
-  ],
+  ['ca614bd8-e4db-4f60-a708-b04d79731f89', { label: 'Buildings', value: 474, comment: '' }],
+  ['6ea103a2-c602-4da4-88b1-3b134016bbdc', { label: 'Other', value: 0, comment: '' }],
   [
     '9be7ad3e-faa0-4010-ad9c-528f91f8ce72',
     { label: 'Incineration of waste', value: 0, comment: '' },
@@ -605,26 +463,17 @@ export const EXPECTED_MEASURES = new Map([
     '714f3c89-3b0b-448e-b55e-97e5bb625678',
     { label: 'Organic decay (waste)', value: 14, comment: '' },
   ],
-  [
-    '75184618-b10d-4ac8-b595-68809b7c53b3',
-    { label: 'Landfill gas', value: 55, comment: '' },
-  ],
+  ['75184618-b10d-4ac8-b595-68809b7c53b3', { label: 'Landfill gas', value: 55, comment: '' }],
   [
     '68102437-5dff-4adc-95d6-9b47bb8a9f4f',
     { label: 'Other waste management', value: 2, comment: '' },
   ],
-  [
-    'fbf3fa68-30be-47c5-a368-decd9d6f16e2',
-    { label: 'Industry (IPPU)', value: 64, comment: '' },
-  ],
+  ['fbf3fa68-30be-47c5-a368-decd9d6f16e2', { label: 'Industry (IPPU)', value: 64, comment: '' }],
   [
     'a08d4504-a43c-4dc1-ac2d-27d7aef5c241',
     { label: 'Agriculture (AFOLU)', value: 138, comment: '' },
   ],
-  [
-    '58c99d80-8b05-4573-8291-9252560414fd',
-    { label: 'Other sources', value: 44, comment: '' },
-  ],
+  ['58c99d80-8b05-4573-8291-9252560414fd', { label: 'Other sources', value: 44, comment: '' }],
   [
     'ca90a93d-5299-42ee-b7c0-909f308e62c9',
     {
@@ -642,18 +491,9 @@ export const EXPECTED_MEASURES = new Map([
       comment: '',
     },
   ],
-  [
-    '6cdd313e-1f72-4168-b48c-ed4da1d28266',
-    { label: 'Buses', value: 10, comment: '' },
-  ],
-  [
-    '162dc3d8-cbe0-4885-ae28-961052468b48',
-    { label: 'Trains/metro', value: 60, comment: '' },
-  ],
-  [
-    'dc70e30c-51dc-4a9b-934a-8eb4c26dca9b',
-    { label: 'Walking/cycling', value: 30, comment: '' },
-  ],
+  ['6cdd313e-1f72-4168-b48c-ed4da1d28266', { label: 'Buses', value: 10, comment: '' }],
+  ['162dc3d8-cbe0-4885-ae28-961052468b48', { label: 'Trains/metro', value: 60, comment: '' }],
+  ['dc70e30c-51dc-4a9b-934a-8eb4c26dca9b', { label: 'Walking/cycling', value: 30, comment: '' }],
   [
     'a5e20d5c-8bd2-4fde-bffb-b032e851ba02',
     {
@@ -675,69 +515,28 @@ export const EXPECTED_MEASURES = new Map([
   [
     '56f01fa8-6c81-4bed-91cf-436d410e3b9a',
     {
-      label:
-        'At what year can we expect the city to reach the maximum value specified above?',
+      label: 'At what year can we expect the city to reach the maximum value specified above?',
       value: 2040,
       comment: '',
     },
   ],
-  [
-    '10528e2b-bec7-4d02-9ef9-ff665d6cc7a1',
-    { label: '2020', value: 0, comment: '' },
-  ],
-  [
-    '5216b4fa-f58a-458a-943b-f576bb679b7a',
-    { label: '2021', value: 0, comment: '' },
-  ],
-  [
-    'c4e0bb4f-a7da-4e04-9bcc-01526769b8d5',
-    { label: '2022', value: 3, comment: '' },
-  ],
-  [
-    'ec005e1f-d6bd-4114-859c-b2c30f4e9dad',
-    { label: '2023', value: 10, comment: '' },
-  ],
-  [
-    '081823a8-67a7-455c-908f-96cc6a36f657',
-    { label: '2024', value: 10, comment: '' },
-  ],
-  [
-    '85facd22-07bb-41a7-88b7-6e90d76c5683',
-    { label: '2025', value: 10, comment: '' },
-  ],
-  [
-    '7f0a41e3-b53a-4c1b-b81d-d493a70ec606',
-    { label: '2026', value: 10, comment: '' },
-  ],
-  [
-    '457adea4-fb53-4e3e-8e2a-b6492637f891',
-    { label: '2027', value: 10, comment: '' },
-  ],
-  [
-    'ff1c126d-5134-437d-9d4d-1237ca1512e8',
-    { label: '2028', value: 15, comment: '' },
-  ],
-  [
-    '3c7ee4f9-6822-43b2-8c23-ba969bdc6f56',
-    { label: '2029', value: 15, comment: '' },
-  ],
-  [
-    '9d381c8c-7c34-4058-a69c-1b06e8117c89',
-    { label: '2030', value: 17, comment: '' },
-  ],
-  [
-    'b74849a8-692a-4020-b337-7dbbc0c93227',
-    { label: 'Light duty trucks', value: 45, comment: '' },
-  ],
-  [
-    '0071013d-6a8e-4a92-ba23-28e85b247a15',
-    { label: 'Heavy duty trucks', value: 60, comment: '' },
-  ],
+  ['10528e2b-bec7-4d02-9ef9-ff665d6cc7a1', { label: '2020', value: 0, comment: '' }],
+  ['5216b4fa-f58a-458a-943b-f576bb679b7a', { label: '2021', value: 0, comment: '' }],
+  ['c4e0bb4f-a7da-4e04-9bcc-01526769b8d5', { label: '2022', value: 3, comment: '' }],
+  ['ec005e1f-d6bd-4114-859c-b2c30f4e9dad', { label: '2023', value: 10, comment: '' }],
+  ['081823a8-67a7-455c-908f-96cc6a36f657', { label: '2024', value: 10, comment: '' }],
+  ['85facd22-07bb-41a7-88b7-6e90d76c5683', { label: '2025', value: 10, comment: '' }],
+  ['7f0a41e3-b53a-4c1b-b81d-d493a70ec606', { label: '2026', value: 10, comment: '' }],
+  ['457adea4-fb53-4e3e-8e2a-b6492637f891', { label: '2027', value: 10, comment: '' }],
+  ['ff1c126d-5134-437d-9d4d-1237ca1512e8', { label: '2028', value: 15, comment: '' }],
+  ['3c7ee4f9-6822-43b2-8c23-ba969bdc6f56', { label: '2029', value: 15, comment: '' }],
+  ['9d381c8c-7c34-4058-a69c-1b06e8117c89', { label: '2030', value: 17, comment: '' }],
+  ['b74849a8-692a-4020-b337-7dbbc0c93227', { label: 'Light duty trucks', value: 45, comment: '' }],
+  ['0071013d-6a8e-4a92-ba23-28e85b247a15', { label: 'Heavy duty trucks', value: 60, comment: '' }],
   [
     'eb7fc66c-1e68-4f1c-9a75-49cd9c174b17',
     {
-      label:
-        'What is the maximum share of the truck fleet that can be electrified?',
+      label: 'What is the maximum share of the truck fleet that can be electrified?',
       value: 90,
       comment: '',
     },
@@ -745,8 +544,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '04088784-13d6-484b-9248-5571877492df',
     {
-      label:
-        'At what year can we expect the city to reach the maximum value specified above?',
+      label: 'At what year can we expect the city to reach the maximum value specified above?',
       value: 2040,
       comment: '',
     },
@@ -754,8 +552,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '269337bc-3908-44f4-8435-ae6f84248756',
     {
-      label:
-        'What is the maximum share of the truck fleet that can be electrified?',
+      label: 'What is the maximum share of the truck fleet that can be electrified?',
       value: 60,
       comment: '',
     },
@@ -763,8 +560,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     'd1cb6ee0-dffb-4132-9aff-05a1fe78bd75',
     {
-      label:
-        'At what year can we expect the city to reach the maximum value specified above?',
+      label: 'At what year can we expect the city to reach the maximum value specified above?',
       value: 2040,
       comment: '',
     },
@@ -836,8 +632,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '577bf77b-825e-43ac-a210-cb2653dc6983',
     {
-      label:
-        'Aggressive efficiency improvements for lighting and appliances (~40%)',
+      label: 'Aggressive efficiency improvements for lighting and appliances (~40%)',
       value: 100,
       comment: '',
     },
@@ -861,8 +656,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '85d468d4-951c-49a7-8b6f-52283af9cbed',
     {
-      label:
-        'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
+      label: 'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
       value: 0,
       comment: '',
     },
@@ -879,19 +673,12 @@ export const EXPECTED_MEASURES = new Map([
     'b9bbce97-4fec-44a8-980c-d78fb446cc76',
     { label: 'Waste (fossil & non-fossil waste)', value: 0, comment: '' },
   ],
-  [
-    '75e49bd5-adff-408b-99d3-3630a63eecba',
-    { label: 'Fossil share', value: 18, comment: '' },
-  ],
-  [
-    'c74c6acc-f9bf-43f4-bf5e-1af86541a92f',
-    { label: 'Non-fossil share', value: 82, comment: '' },
-  ],
+  ['75e49bd5-adff-408b-99d3-3630a63eecba', { label: 'Fossil share', value: 18, comment: '' }],
+  ['c74c6acc-f9bf-43f4-bf5e-1af86541a92f', { label: 'Non-fossil share', value: 82, comment: '' }],
   [
     '653ef9da-2820-4de1-bb3e-1c85f76eab35',
     {
-      label:
-        'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
+      label: 'Fossil (oil, coal, gas) + inefficient electric heating (not heat pumps)',
       value: 25,
       comment: '',
     },
@@ -900,10 +687,7 @@ export const EXPECTED_MEASURES = new Map([
     '7443c2c6-9218-4c4a-8fe3-523a43548003',
     { label: 'Electric (heat pumps)', value: 60, comment: '' },
   ],
-  [
-    '1d58badb-c62c-4c1b-9824-e092b305746e',
-    { label: 'Biobased', value: 15, comment: '' },
-  ],
+  ['1d58badb-c62c-4c1b-9824-e092b305746e', { label: 'Biobased', value: 15, comment: '' }],
   [
     '619aa8c7-c144-4392-91d0-c4e472f0fc6a',
     {
@@ -923,8 +707,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '18b9b8ac-cd73-4551-8628-16c6f4fbc649',
     {
-      label:
-        'Share of current fossil production replaced by renewables (or nuclear)',
+      label: 'Share of current fossil production replaced by renewables (or nuclear)',
       value: 85,
       comment: '',
     },
@@ -937,66 +720,21 @@ export const EXPECTED_MEASURES = new Map([
     'ad4bf140-bfdc-476d-85f8-a898f21edf81',
     { label: 'Centralised Solar PV/wind farms', value: 95, comment: '' },
   ],
-  [
-    'e1eddc0b-576a-4810-aa76-2fdcc050dbde',
-    { label: 'Landfill', value: 0, comment: '' },
-  ],
-  [
-    '011e6229-bb54-4d26-a525-13811176307c',
-    { label: 'Incineration', value: 15, comment: '' },
-  ],
-  [
-    '37743e60-348e-42dd-8c13-24aea2a118be',
-    { label: 'Recycling', value: 85, comment: '' },
-  ],
-  [
-    '9ff4ebeb-6ccd-4a8e-8b81-b4f6bea06bd8',
-    { label: 'Landfill', value: 10, comment: '' },
-  ],
-  [
-    '44966333-9664-4f13-b12a-f222d6569dce',
-    { label: 'Incineration', value: 5, comment: '' },
-  ],
-  [
-    '767e7ea7-0185-494b-8749-84d44949a580',
-    { label: 'Recycling', value: 85, comment: '' },
-  ],
-  [
-    '1026d3a0-b895-464b-9c3a-ce10a1e5c5aa',
-    { label: 'Landfill', value: 10, comment: '' },
-  ],
-  [
-    '40471ce7-6885-4026-8801-cf9bbc44e77b',
-    { label: 'Incineration', value: 22, comment: '' },
-  ],
-  [
-    'ac9cdd26-0874-45df-afa7-739bd7307457',
-    { label: 'Recycling', value: 68, comment: '' },
-  ],
-  [
-    '99c6d0ab-1a7a-4e1c-8f58-54bee1f1e42b',
-    { label: 'Landfill', value: 10, comment: '' },
-  ],
-  [
-    '57756603-7d42-490d-be3c-35282a6bd24b',
-    { label: 'Incineration', value: 5, comment: '' },
-  ],
-  [
-    '842ded5f-1c1d-43d9-a868-e8a186994360',
-    { label: 'Recycling', value: 85, comment: '' },
-  ],
-  [
-    '3ef0c01b-0631-4a7d-992d-3ce988d215cb',
-    { label: 'Landfill', value: 0, comment: '' },
-  ],
-  [
-    'db853cd0-0d13-45e2-9097-bd50b53cc57c',
-    { label: 'Incineration', value: 15, comment: '' },
-  ],
-  [
-    '9557785b-f6be-44a7-a7e9-9b025e93c473',
-    { label: 'Composting', value: 85, comment: '' },
-  ],
+  ['e1eddc0b-576a-4810-aa76-2fdcc050dbde', { label: 'Landfill', value: 0, comment: '' }],
+  ['011e6229-bb54-4d26-a525-13811176307c', { label: 'Incineration', value: 15, comment: '' }],
+  ['37743e60-348e-42dd-8c13-24aea2a118be', { label: 'Recycling', value: 85, comment: '' }],
+  ['9ff4ebeb-6ccd-4a8e-8b81-b4f6bea06bd8', { label: 'Landfill', value: 10, comment: '' }],
+  ['44966333-9664-4f13-b12a-f222d6569dce', { label: 'Incineration', value: 5, comment: '' }],
+  ['767e7ea7-0185-494b-8749-84d44949a580', { label: 'Recycling', value: 85, comment: '' }],
+  ['1026d3a0-b895-464b-9c3a-ce10a1e5c5aa', { label: 'Landfill', value: 10, comment: '' }],
+  ['40471ce7-6885-4026-8801-cf9bbc44e77b', { label: 'Incineration', value: 22, comment: '' }],
+  ['ac9cdd26-0874-45df-afa7-739bd7307457', { label: 'Recycling', value: 68, comment: '' }],
+  ['99c6d0ab-1a7a-4e1c-8f58-54bee1f1e42b', { label: 'Landfill', value: 10, comment: '' }],
+  ['57756603-7d42-490d-be3c-35282a6bd24b', { label: 'Incineration', value: 5, comment: '' }],
+  ['842ded5f-1c1d-43d9-a868-e8a186994360', { label: 'Recycling', value: 85, comment: '' }],
+  ['3ef0c01b-0631-4a7d-992d-3ce988d215cb', { label: 'Landfill', value: 0, comment: '' }],
+  ['db853cd0-0d13-45e2-9097-bd50b53cc57c', { label: 'Incineration', value: 15, comment: '' }],
+  ['9557785b-f6be-44a7-a7e9-9b025e93c473', { label: 'Composting', value: 85, comment: '' }],
   [
     'a5b89b5a-bdc6-44e9-a645-a8bce2dc8313',
     { label: 'Trees planted inside city', value: 20000, comment: '' },
@@ -1024,8 +762,7 @@ export const EXPECTED_MEASURES = new Map([
   [
     '7d90be89-452c-4238-bb38-4646cc49aa10',
     {
-      label:
-        'Population density outside city (used to scale benefits from forestation)',
+      label: 'Population density outside city (used to scale benefits from forestation)',
       value: 10,
       comment: '',
     },
@@ -1039,3 +776,45 @@ export const EXPECTED_MEASURES = new Map([
     },
   ],
 ]);
+
+const REMOVED_UUIDS = new Set([
+  '00924063-1dd8-43b1-a118-f3e29edbecf7',
+  '08bb8fb2-9b5d-4d9f-87e6-2e1abffd208c',
+  '11d16a62-2f77-437c-b586-3a86586edac6',
+  '14417928-7d7f-49d5-8d59-3114be77792d',
+  '1648bc36-3c36-47f1-bd03-78f7969923b6',
+  '1a328799-4774-4901-be1f-e6b46fb84ef7',
+  '22545669-4941-445a-bac5-290acf43b110',
+  '22dcb86a-4523-466d-be25-8b2fe4a58c20',
+  '2fe95f5c-5895-4239-a3f9-64425da2e6e4',
+  '373e44dd-2127-4feb-b60c-94af0489d82e',
+  '46fdb8f7-3125-4689-be93-7b1c03abf98c',
+  '501d46fa-6d86-422f-a818-b712612995c4',
+  '51626bc7-17ca-4086-bca8-6ad806bbc224',
+  '53b815ee-ad74-4aad-8096-3ba19af4e6f4',
+  '56ad8ce0-a583-4011-846d-ad44cbc92052',
+  '5c1b815c-6c13-4303-b9ff-f641cd725c4e',
+  '6be10a46-8b31-46a5-a454-42b30d7f3e6f',
+  '7165c4b8-76a9-4d8a-b437-55f6099dd1ac',
+  '7ade3b4c-c3b1-4727-82d5-f36d1955e18f',
+  '7d90be89-452c-4238-bb38-4646cc49aa10',
+  '80414475-5306-4e66-8ff9-c15f346c61fe',
+  '8e9c2502-128f-4368-ad09-debb8d2e06c8',
+  '90fb1c6f-d882-4995-96bf-d2e190c406e4',
+  '93b7feab-da6a-4f33-8726-2ca7c96046b6',
+  '9bebc7be-cc99-4edb-9932-a4465baa4748',
+  'a4081684-e1c5-4e98-8481-3cef7efc65ff',
+  'a5b89b5a-bdc6-44e9-a645-a8bce2dc8313',
+  'ac14daee-a60e-445a-b56b-bc0600e9788d',
+  'ad674916-c0b8-49af-a2ff-4ea20e29a73e',
+  'bc158706-a7dd-4ebe-b712-1cb8f4d43659',
+  'e1069a45-21db-4210-96a3-71210c7a9cf8',
+  'f8d3b736-1fe9-49ce-851b-d881f11d8a89',
+  'f9721db6-29dc-4a14-abb9-1cd644d05b39',
+  'fae64934-4d43-4b58-9ee4-9f7b37cd7335',
+  'fd2e2ed0-26de-4ca4-afa5-889e6cceb9fa',
+]);
+
+export const EXPECTED_MEASURES = new Map(
+  [...ALL_MEASURES].filter(([uuid]) => !REMOVED_UUIDS.has(uuid))
+);

--- a/src/utils/csv-import/csv-import.tsx
+++ b/src/utils/csv-import/csv-import.tsx
@@ -6,15 +6,14 @@
  * collection Excel, along with the parent section name and corresponding UUID
  * of the measure in the database.
  */
-
 import Papa from 'papaparse';
 
-import legacyMeasureMap from './legacy-measure-map.json';
 import { convertStringToNumber, isStringNumber } from '../numbers';
+import legacyMeasureMap from './legacy-measure-map.json';
 
 const NOT_FOUND_ERROR = 'Unable to parse the row.';
 const GENERAL_ERROR = 'Unable to parse the file.';
-const SPREADSHEET_PRIORITIES = ['High', 'Moderate', 'Low'];
+const SPREADSHEET_PRIORITIES = ['High', 'Moderate'];
 const EXCLUDED_ROWS_BY_LABEL = [
   /^(Total)$/,
   /^(Legend for cell colour coding)$/,
@@ -27,8 +26,7 @@ const EXPECTED_INVALID_PRIORITY = [
   'Reduction of total distance travelled through route optimisation',
 ];
 
-const isValidPriority = (priority: string) =>
-  SPREADSHEET_PRIORITIES.includes(priority);
+const isValidPriority = (priority: string) => SPREADSHEET_PRIORITIES.includes(priority);
 
 type ImportedMeasure = {
   label: string;
@@ -72,22 +70,15 @@ export function parseMeasuresCsv(csvData: string): ParsedCsvResponse {
     const strValue = rowValues[3]?.trim();
     const priority = rowValues[7]?.trim();
     const comment = rowValues[8]?.trim();
-    const value = isStringNumber(strValue)
-      ? convertStringToNumber(strValue)
-      : null;
+    const value = isStringNumber(strValue) ? convertStringToNumber(strValue) : null;
 
-    if (
-      !label ||
-      EXCLUDED_ROWS_BY_LABEL.some((excludedLabel) => label.match(excludedLabel))
-    ) {
+    if (!label || EXCLUDED_ROWS_BY_LABEL.some((excludedLabel) => label.match(excludedLabel))) {
       previousRow = label;
       return;
     }
 
     const isSection =
-      unit === '' ||
-      (!isValidPriority(priority) &&
-        !EXPECTED_INVALID_PRIORITY.includes(label));
+      unit === '' || (!isValidPriority(priority) && !EXPECTED_INVALID_PRIORITY.includes(label));
 
     if (isSection) {
       currentSection = label;
@@ -95,9 +86,7 @@ export function parseMeasuresCsv(csvData: string): ParsedCsvResponse {
       return;
     }
 
-    const matchesByName = legacyMeasureMap.filter(
-      (measure) => measure.name === label
-    );
+    const matchesByName = legacyMeasureMap.filter((measure) => measure.name === label);
 
     const importedMeasure = { label, value, comment };
 
@@ -107,9 +96,7 @@ export function parseMeasuresCsv(csvData: string): ParsedCsvResponse {
       measuresNotFound.push(importedMeasure);
     } else {
       // Multiple measures found with the same name, filter by parent section
-      const measures = matchesByName.filter(
-        (measure) => measure.parentSection === currentSection
-      );
+      const measures = matchesByName.filter((measure) => measure.parentSection === currentSection);
 
       /**
        * Some freight transportation measures have the same name and parent section,
@@ -144,9 +131,6 @@ export function parseMeasuresCsv(csvData: string): ParsedCsvResponse {
 
   return {
     measures: measureValueMap,
-    errors: [
-      ...(measureValueMap.size === 0 ? [generalError] : []),
-      ...measureErrors,
-    ],
+    errors: [...(measureValueMap.size === 0 ? [generalError] : []), ...measureErrors],
   };
 }


### PR DESCRIPTION
Since there were only two low priority inputs remaining after reducing the input count for easier data entry, we decided to scrap the low priority classification. The remaining two low priority data points have been migrated to medium.