### PR TITLE
Fix bus electrification validation and support minimum total validation

### DIFF
--- a/src/components/AdditionalDatasheetEditor.tsx
+++ b/src/components/AdditionalDatasheetEditor.tsx
@@ -122,7 +122,9 @@ function getRowsFromSection(
 ): Row[] {
   const sectionRow: SectionRow = {
     type: 'SECTION',
-    sumTo100: section.maxTotal === 100 && measureTemplates.length > 1,
+    sumMeasureValues:
+      (typeof section.minTotal === 'number' || typeof section.maxTotal === 'number') &&
+      measureTemplates.length > 1,
     isTitle: true,
     label: section.name,
     helpText: section.helpText,
@@ -172,7 +174,7 @@ function getRowsFromSection(
         ),
       })
     ),
-    ...(sectionRow.sumTo100
+    ...(sectionRow.sumMeasureValues
       ? [getSumPercentRow({ measureTemplates, childSections, ...section }, depth + 1)]
       : []),
     ...childSections.flatMap((section) =>

--- a/src/components/DataCollection.tsx
+++ b/src/components/DataCollection.tsx
@@ -158,7 +158,6 @@ const DataCollection = ({ measureTemplates }: Props) => {
           <DatasheetEditor
             sections={assumptionMeasures}
             allInfluencingMeasureTemplates={allInfluencingMeasureTemplates}
-            withIndexes
           />
         )}
       </CustomTabPanel>

--- a/src/components/DataCollection.tsx
+++ b/src/components/DataCollection.tsx
@@ -1,17 +1,23 @@
 'use client';
 
-import * as React from 'react';
-import { Box, Tabs, Tab, Card, Typography } from '@mui/material';
+import { type ReactNode, type SyntheticEvent, useMemo } from 'react';
+
+import { Box, Card, Tab, Tabs, Typography } from '@mui/material';
+
 import { DatasheetEditor } from '@/components/DatasheetEditor';
-import type { Tab as TTab} from '@/store/data-collection';
-import { useDataCollectionStore } from '@/store/data-collection';
-import type { GetMeasureTemplatesQuery } from '@/types/__generated__/graphql';
-import { mapMeasureTemplatesToRows } from '@/utils/measures';
 import { useDefaultTargetYear } from '@/hooks/use-framework-settings';
+import type { Tab as TTab } from '@/store/data-collection';
+import { useDataCollectionStore } from '@/store/data-collection';
+import type {
+  GetMeasureTemplatesQuery,
+  MeasureTemplateFragmentFragment,
+} from '@/types/__generated__/graphql';
+import { mapMeasureTemplatesToRows } from '@/utils/measures';
+
 import { useSuspenseSelectedPlanConfig } from './providers/SelectedPlanProvider';
 
 interface TabPanelProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   index: TTab;
   selected: TTab;
 }
@@ -39,6 +45,48 @@ function a11yProps(tab: TTab) {
   };
 }
 
+/**
+ * Returns the measure template objects that are associated with
+ * other sections under section.influencingMeasureTemplates.
+ */
+function useInfluencingMeasureTemplates(
+  measureTemplates: NonNullable<GetMeasureTemplatesQuery['framework']>
+) {
+  const influencingMeasureTemplates = useMemo<MeasureTemplateFragmentFragment[]>(() => {
+    const sections = [
+      ...(measureTemplates.dataCollection?.descendants ?? []),
+      ...(measureTemplates.futureAssumptions?.descendants ?? []),
+    ];
+
+    const flatMeasureTemplates = new Map(
+      [
+        ...(measureTemplates.dataCollection?.descendants ?? []),
+        ...(measureTemplates.futureAssumptions?.descendants ?? []),
+      ]
+        .flatMap((section) => section.measureTemplates)
+        .map((measureTemplate) => [measureTemplate.uuid, measureTemplate])
+    );
+
+    const influencingMeasureTemplateUUIDs = new Set(
+      sections
+        .filter(
+          (section) =>
+            'influencingMeasureTemplates' in section &&
+            section.influencingMeasureTemplates instanceof Array
+        )
+        .flatMap(({ influencingMeasureTemplates }) =>
+          influencingMeasureTemplates.map((template) => template.uuid).filter(Boolean)
+        )
+    );
+
+    return [...influencingMeasureTemplateUUIDs]
+      .map((uuid) => flatMeasureTemplates.get(uuid))
+      .filter((template): template is MeasureTemplateFragmentFragment => template != null);
+  }, [measureTemplates]);
+
+  return influencingMeasureTemplates;
+}
+
 type Props = {
   measureTemplates: NonNullable<GetMeasureTemplatesQuery['framework']>;
 };
@@ -52,7 +100,7 @@ const DataCollection = ({ measureTemplates }: Props) => {
 
   const defaultTargetYear = useDefaultTargetYear();
 
-  const handleChange = (event: React.SyntheticEvent, newSelected: TTab) => {
+  const handleChange = (event: SyntheticEvent, newSelected: TTab) => {
     setSelectedTab(newSelected);
   };
 
@@ -72,19 +120,13 @@ const DataCollection = ({ measureTemplates }: Props) => {
       )
     : undefined;
 
+  const allInfluencingMeasureTemplates = useInfluencingMeasureTemplates(measureTemplates);
+
   return (
     <Card>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs
-          value={selectedTab}
-          onChange={handleChange}
-          aria-label="basic tabs example"
-        >
-          <Tab
-            label={`Data collection (${baselineYear})`}
-            value="data"
-            {...a11yProps('data')}
-          />
+        <Tabs value={selectedTab} onChange={handleChange} aria-label="basic tabs example">
+          <Tab label={`Data collection (${baselineYear})`} value="data" {...a11yProps('data')} />
           <Tab
             label={`Future assumptions (${targetYear || defaultTargetYear})`}
             value="assumptions"
@@ -93,23 +135,31 @@ const DataCollection = ({ measureTemplates }: Props) => {
         </Tabs>
       </Box>
       <CustomTabPanel selected={selectedTab} index={'data'}>
-        <Typography paragraph gutterBottom>
-          Collect essential data about your city&apos;s current state across key
-          sectors. This phase focuses on gathering raw data to establish a
-          baseline for your city&apos;s climate initiatives.
+        <Typography gutterBottom>
+          Collect essential data about your city&apos;s current state across key sectors. This phase
+          focuses on gathering raw data to establish a baseline for your city&apos;s climate
+          initiatives.
         </Typography>
         {!!dataMeasures && (
-          <DatasheetEditor sections={dataMeasures} withIndexes />
+          <DatasheetEditor
+            sections={dataMeasures}
+            allInfluencingMeasureTemplates={allInfluencingMeasureTemplates}
+            withIndexes
+          />
         )}
       </CustomTabPanel>
       <CustomTabPanel selected={selectedTab} index={'assumptions'}>
         <Typography paragraph gutterBottom>
-          These assumptions should reflect an ambitious yet feasible scenario
-          aligned with the city&apos;s Climate Action Plan, indicating the
-          extent to which the city aims to achieve decarbonisation goals.
+          These assumptions should reflect an ambitious yet feasible scenario aligned with the
+          city&apos;s Climate Action Plan, indicating the extent to which the city aims to achieve
+          decarbonisation goals.
         </Typography>
         {!!assumptionMeasures && (
-          <DatasheetEditor sections={assumptionMeasures} />
+          <DatasheetEditor
+            sections={assumptionMeasures}
+            allInfluencingMeasureTemplates={allInfluencingMeasureTemplates}
+            withIndexes
+          />
         )}
       </CustomTabPanel>
     </Card>

--- a/src/queries/get-measure-templates.ts
+++ b/src/queries/get-measure-templates.ts
@@ -31,6 +31,10 @@ export const GET_MEASURE_TEMPLATES = gql`
     __typename
     uuid
     name
+    influencingMeasureTemplates {
+      uuid
+    }
+    minTotal
     maxTotal
     helpText
     path

--- a/src/types/__generated__/graphql.ts
+++ b/src/types/__generated__/graphql.ts
@@ -2201,8 +2201,10 @@ export type Section = {
   helpText: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   identifier?: Maybe<Scalars['String']['output']>;
+  influencingMeasureTemplates: Array<MeasureTemplate>;
   maxTotal?: Maybe<Scalars['Float']['output']>;
   measureTemplates: Array<MeasureTemplate>;
+  minTotal?: Maybe<Scalars['Float']['output']>;
   name: Scalars['String']['output'];
   parent?: Maybe<Section>;
   path: Scalars['String']['output'];
@@ -2787,7 +2789,10 @@ export type GetMeasureTemplatesQuery = (
   { framework?: (
     { id: string, dataCollection?: (
       { uuid: string, descendants: Array<(
-        { uuid: string, name: string, maxTotal?: number | null, helpText: string, path: string, parent?: (
+        { uuid: string, name: string, minTotal?: number | null, maxTotal?: number | null, helpText: string, path: string, influencingMeasureTemplates: Array<(
+          { uuid: string }
+          & { __typename?: 'MeasureTemplate' }
+        )>, parent?: (
           { uuid: string }
           & { __typename?: 'Section' }
         ) | null, measureTemplates: Array<(
@@ -2814,7 +2819,10 @@ export type GetMeasureTemplatesQuery = (
       & { __typename?: 'Section' }
     ) | null, futureAssumptions?: (
       { uuid: string, descendants: Array<(
-        { uuid: string, name: string, maxTotal?: number | null, helpText: string, path: string, parent?: (
+        { uuid: string, name: string, minTotal?: number | null, maxTotal?: number | null, helpText: string, path: string, influencingMeasureTemplates: Array<(
+          { uuid: string }
+          & { __typename?: 'MeasureTemplate' }
+        )>, parent?: (
           { uuid: string }
           & { __typename?: 'Section' }
         ) | null, measureTemplates: Array<(
@@ -2850,7 +2858,10 @@ export type GetMeasureTemplatesQuery = (
 
 export type MainSectionMeasuresFragment = (
   { uuid: string, descendants: Array<(
-    { uuid: string, name: string, maxTotal?: number | null, helpText: string, path: string, parent?: (
+    { uuid: string, name: string, minTotal?: number | null, maxTotal?: number | null, helpText: string, path: string, influencingMeasureTemplates: Array<(
+      { uuid: string }
+      & { __typename?: 'MeasureTemplate' }
+    )>, parent?: (
       { uuid: string }
       & { __typename?: 'Section' }
     ) | null, measureTemplates: Array<(
@@ -2878,7 +2889,10 @@ export type MainSectionMeasuresFragment = (
 );
 
 export type SectionFragmentFragment = (
-  { uuid: string, name: string, maxTotal?: number | null, helpText: string, path: string, parent?: (
+  { uuid: string, name: string, minTotal?: number | null, maxTotal?: number | null, helpText: string, path: string, influencingMeasureTemplates: Array<(
+    { uuid: string }
+    & { __typename?: 'MeasureTemplate' }
+  )>, parent?: (
     { uuid: string }
     & { __typename?: 'Section' }
   ) | null, measureTemplates: Array<(

--- a/src/utils/measures.tsx
+++ b/src/utils/measures.tsx
@@ -24,6 +24,8 @@ type SectionOrMeasure = MainSectionMeasuresFragment['descendants'][0];
 export type Section = BaseSectionOrMeasure & {
   type: 'ACCORDION_SECTION' | 'SECTION';
   childSections: Section[];
+  influencingMeasureTemplates: { uuid: string }[] | null;
+  minTotal: number | null;
   maxTotal: number | null;
   helpText: string | null;
   measureTemplates?: MeasureTemplateFragmentFragment[];
@@ -81,6 +83,8 @@ export function mapMeasureTemplatesToRows(
           name: section.name,
           childSections: createChildren(section.uuid, sections),
           type: section.parent?.uuid === mainSection.uuid ? 'ACCORDION_SECTION' : 'SECTION',
+          influencingMeasureTemplates: section.influencingMeasureTemplates ?? null,
+          minTotal: section.minTotal ?? null,
           maxTotal: section.maxTotal ?? null,
           helpText: section.helpText ?? null,
           measureTemplates,


### PR DESCRIPTION
## Description
Fix incorrect validation of bus electrification. Previously, all section validation checked that all measures in a section summed to exactly 100%. With this change, sections are validated so that the sum of their measures is between `section.minTotal` and `section.maxTotal`.

In the case of bus electrification, a measure from a different section needed to be included in the section sum. _(Passenger transportation → Buses - other data → Share of bus fleet as fully electric buses (not including hybrids))_ for the baseline year is included in calculations for future assumptions. The bus electrification future assumptions section _(Future assumptions → Passenger transportation levers → 1.4.2 Electrification of buses → Expected procurement schedule for buses)_ now includes the baseline value in the calculation based on a new `influencingMeasureTemplates` property.

## Screenshots/Videos (if applicable)

<img width="1166" height="629" alt="image" src="https://github.com/user-attachments/assets/b8959b34-4928-4d3f-819b-ccfb35b17c8f" />

## Related issue
[🎟️ Asana ticket](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1211532993055285?focus=true)

------

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Authorization is tested** (permissions and access controls verified)
- [x] **Mobile screen widths tested for responsiveness** (if applicable)
- [x] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    1. Check out the branch
    2. Add a value for passenger transportation → share of bus fleet fully electric
    3. Go to the Future assumptions tab
    4. Add values for passenger transportation levers → electrification of buses → year
    5. The sum of all values for each year entered plus the value in step 2 should be validated
    6. If the total sum is above 100, a warning should be shown at the total % sum under the year values
    7. If it is below 100, no warning should be shown, but help text should be visible on hover of the Total %
    
### Internationalization & Accessibility
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)
