### PR TITLE
Add delete and lock plan support

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -214,7 +214,7 @@ export default function DashboardContent() {
                     <Alert
                       severity="warning"
                       action={
-                        permissions.isFrameworkAdmin ? (
+                        permissions.isAdmin ? (
                           <Button
                             color="inherit"
                             size="small"

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import {
+  Alert,
   Button,
   Card,
   CardContent,
@@ -13,18 +14,24 @@ import {
   Typography,
 } from '@mui/material';
 import * as Sentry from '@sentry/nextjs';
-import { BoxArrowUpRight, Download } from 'react-bootstrap-icons';
+import { BoxArrowUpRight, Download, Unlock } from 'react-bootstrap-icons';
 import { serializeError } from 'serialize-error';
 
 import CompletionScoreCard from '@/components/CompletionScoreCard';
 import DataCollection from '@/components/DataCollection';
 import { HelpText } from '@/components/HelpText';
 import IntroSection from '@/components/IntroSection';
+import { useSnackbar } from '@/components/SnackbarProvider';
 import { ImportExportActions } from '@/components/import-export/ImportExportActions';
 import { SUPPORT_FORM_URL } from '@/components/links';
 import { usePlans } from '@/components/providers/SelectedPlanProvider';
 import { benefits } from '@/constants/intro-content';
 import { usePermissions } from '@/hooks/use-user-profile';
+import {
+  LOCK_FRAMEWORK_CONFIG,
+  type LockFrameworkConfigMutation,
+  type LockFrameworkConfigMutationVariables,
+} from '@/queries/framework/lock-framework-config';
 import { GET_MEASURE_TEMPLATES } from '@/queries/get-measure-templates';
 import type {
   GetMeasureTemplatesQuery,
@@ -95,11 +102,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
   return (
     <Fade in>
       <div>
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-        >
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography gutterBottom variant="h3" component="h2">
             Data collection center
           </Typography>
@@ -109,9 +112,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
             </Stack>
           )}
         </Stack>
-        {!!data.framework && (
-          <DataCollection measureTemplates={data.framework} />
-        )}
+        {!!data.framework && <DataCollection measureTemplates={data.framework} />}
       </div>
     </Fade>
   );
@@ -120,6 +121,30 @@ function DataCollectionContent({ instance }: { instance: string }) {
 export default function DashboardContent() {
   const { allPlans, selectedPlan } = usePlans();
   const permissions = usePermissions();
+  const { setNotification } = useSnackbar();
+
+  const [unlockPlan, { loading: unlocking }] = useMutation<
+    LockFrameworkConfigMutation,
+    LockFrameworkConfigMutationVariables
+  >(LOCK_FRAMEWORK_CONFIG);
+
+  async function handleUnlock() {
+    if (!selectedPlan) return;
+
+    try {
+      await unlockPlan({ variables: { id: selectedPlan.id, locked: false } });
+
+      setNotification({
+        message: `"${selectedPlan.organizationName}" unlocked. Editing has been enabled.`,
+        severity: 'success',
+      });
+    } catch {
+      setNotification({
+        message: 'Failed to unlock the plan. Please try again.',
+        severity: 'error',
+      });
+    }
+  }
 
   if (allPlans === null) {
     return <Loading />;
@@ -139,13 +164,9 @@ export default function DashboardContent() {
                   It looks like there aren't any plans for your city yet.{' '}
                   {!permissions.create ? (
                     <>
-                      You don't currently have permission to create one. To
-                      request edit access, please fill out{' '}
-                      <Link
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href={SUPPORT_FORM_URL}
-                      >
+                      You don't currently have permission to create one. To request edit access,
+                      please fill out{' '}
+                      <Link target="_blank" rel="noopener noreferrer" href={SUPPORT_FORM_URL}>
                         this form
                       </Link>
                       .
@@ -184,16 +205,32 @@ export default function DashboardContent() {
               <CardContent>
                 <Stack spacing={2}>
                   <div>
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      justifyContent="space-between"
-                    >
-                      <Typography variant="h1">
-                        {selectedPlan.organizationName}
-                      </Typography>
+                    <Stack direction="row" alignItems="center" justifyContent="space-between">
+                      <Typography variant="h1">{selectedPlan.organizationName}</Typography>
                     </Stack>
                   </div>
+
+                  {selectedPlan.locked && (
+                    <Alert
+                      severity="warning"
+                      action={
+                        permissions.isFrameworkAdmin ? (
+                          <Button
+                            color="inherit"
+                            size="small"
+                            startIcon={<Unlock size={14} />}
+                            onClick={void handleUnlock}
+                            disabled={unlocking}
+                          >
+                            Unlock plan
+                          </Button>
+                        ) : undefined
+                      }
+                    >
+                      <strong>This plan is locked.</strong> Data entry and edits are disabled for
+                      all users until an admin unlocks it.
+                    </Alert>
+                  )}
 
                   {selectedPlan ? (
                     <CompletionScoreCardWrapper instance={selectedPlan.id} />
@@ -225,13 +262,11 @@ export default function DashboardContent() {
                         <HelpText
                           text={
                             <>
-                              Here you can download tables that are helpful in
-                              building an Economic Case for your Climate Action
-                              Plan. These tables display an analysis of GHG
-                              reduction along with the costs and benefits by
-                              sub-sector and stakeholder group. This will
-                              provide you with both the GHG and financial Return
-                              on Investment for better decision making in your
+                              Here you can download tables that are helpful in building an Economic
+                              Case for your Climate Action Plan. These tables display an analysis of
+                              GHG reduction along with the costs and benefits by sub-sector and
+                              stakeholder group. This will provide you with both the GHG and
+                              financial Return on Investment for better decision making in your
                               Climate Action Plan.
                             </>
                           }
@@ -244,11 +279,7 @@ export default function DashboardContent() {
             </Card>
           )}
 
-          {selectedPlan ? (
-            <DataCollectionContent instance={selectedPlan.id} />
-          ) : (
-            <LoadingCard />
-          )}
+          {selectedPlan ? <DataCollectionContent instance={selectedPlan.id} /> : <LoadingCard />}
         </Stack>
       </Container>
     </Fade>

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -199,6 +199,34 @@ export default function DashboardContent() {
             </Skeleton>
           ) : (
             <Card>
+              {selectedPlan.isLocked && (
+                <Alert
+                  severity="warning"
+                  sx={(theme) => ({
+                    borderTopLeftRadius: Number(theme.shape.borderRadius) * 2,
+                    borderTopRightRadius: Number(theme.shape.borderRadius) * 2,
+                    borderBottomLeftRadius: 0,
+                    borderBottomRightRadius: 0,
+                  })}
+                  action={
+                    permissions.isAdmin ? (
+                      <Button
+                        color="inherit"
+                        size="small"
+                        startIcon={<Unlock size={14} />}
+                        onClick={() => void handleUnlock()}
+                        disabled={unlocking}
+                      >
+                        Unlock plan
+                      </Button>
+                    ) : undefined
+                  }
+                >
+                  <strong>This plan is locked.</strong> Data entry and edits are disabled for all
+                  users until an admin unlocks it.
+                </Alert>
+              )}
+
               <CardContent>
                 <Stack spacing={2}>
                   <div>
@@ -206,28 +234,6 @@ export default function DashboardContent() {
                       <Typography variant="h1">{selectedPlan.organizationName}</Typography>
                     </Stack>
                   </div>
-
-                  {selectedPlan.isLocked && (
-                    <Alert
-                      severity="warning"
-                      action={
-                        permissions.isAdmin ? (
-                          <Button
-                            color="inherit"
-                            size="small"
-                            startIcon={<Unlock size={14} />}
-                            onClick={() => void handleUnlock()}
-                            disabled={unlocking}
-                          >
-                            Unlock plan
-                          </Button>
-                        ) : undefined
-                      }
-                    >
-                      <strong>This plan is locked.</strong> Data entry and edits are disabled for
-                      all users until an admin unlocks it.
-                    </Alert>
-                  )}
 
                   {selectedPlan ? (
                     <CompletionScoreCardWrapper instance={selectedPlan.id} />

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import {
   Alert,
   Button,
@@ -27,11 +27,7 @@ import { SUPPORT_FORM_URL } from '@/components/links';
 import { usePlans } from '@/components/providers/SelectedPlanProvider';
 import { benefits } from '@/constants/intro-content';
 import { usePermissions } from '@/hooks/use-user-profile';
-import {
-  LOCK_FRAMEWORK_CONFIG,
-  type LockFrameworkConfigMutation,
-  type LockFrameworkConfigMutationVariables,
-} from '@/queries/framework/lock-framework-config';
+import { useSetInstanceLocked } from '@/queries/framework/lock-framework-config';
 import { GET_MEASURE_TEMPLATES } from '@/queries/get-measure-templates';
 import type {
   GetMeasureTemplatesQuery,
@@ -106,7 +102,7 @@ function DataCollectionContent({ instance }: { instance: string }) {
           <Typography gutterBottom variant="h3" component="h2">
             Data collection center
           </Typography>
-          {!!data.framework && permissions.edit && (
+          {!!data.framework && permissions.edit && !permissions.isLocked && (
             <Stack direction="row" spacing={2}>
               <ImportExportActions measureTemplates={data.framework} />
             </Stack>
@@ -123,16 +119,17 @@ export default function DashboardContent() {
   const permissions = usePermissions();
   const { setNotification } = useSnackbar();
 
-  const [unlockPlan, { loading: unlocking }] = useMutation<
-    LockFrameworkConfigMutation,
-    LockFrameworkConfigMutationVariables
-  >(LOCK_FRAMEWORK_CONFIG);
+  const [unlockPlan, { loading: unlocking }] = useSetInstanceLocked(selectedPlan?.id);
 
   async function handleUnlock() {
-    if (!selectedPlan) return;
+    if (!selectedPlan || !selectedPlan.instanceIdentifier) {
+      return;
+    }
 
     try {
-      await unlockPlan({ variables: { id: selectedPlan.id, locked: false } });
+      await unlockPlan({
+        variables: { instanceId: selectedPlan.instanceIdentifier, isLocked: false },
+      });
 
       setNotification({
         message: `"${selectedPlan.organizationName}" unlocked. Editing has been enabled.`,
@@ -210,7 +207,7 @@ export default function DashboardContent() {
                     </Stack>
                   </div>
 
-                  {selectedPlan.locked && (
+                  {selectedPlan.isLocked && (
                     <Alert
                       severity="warning"
                       action={
@@ -219,7 +216,7 @@ export default function DashboardContent() {
                             color="inherit"
                             size="small"
                             startIcon={<Unlock size={14} />}
-                            onClick={void handleUnlock}
+                            onClick={() => void handleUnlock()}
                             disabled={unlocking}
                           >
                             Unlock plan

--- a/src/components/AdditionalDatasheetEditor.tsx
+++ b/src/components/AdditionalDatasheetEditor.tsx
@@ -505,8 +505,8 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
 
   return (
     <DataGrid<Row>
-      key={selectedPlanId} // Force full re-render when the plan changes
-      {...(permissions.edit ? singleClickEditProps : {})}
+      key={`${selectedPlanId}-${String(permissions.isLocked)}`}
+      {...(permissions.edit && !permissions.isLocked ? singleClickEditProps : {})}
       loading={loading}
       slots={{ footer: CustomFooter }}
       slotProps={{
@@ -514,7 +514,12 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
       }}
       sx={DATA_GRID_SX}
       isCellEditable={(params) =>
-        !!(permissions.edit && params.colDef.editable && params.row.type !== 'SUM_PERCENT')
+        !!(
+          permissions.edit &&
+          !permissions.isLocked &&
+          params.colDef.editable &&
+          params.row.type !== 'SUM_PERCENT'
+        )
       }
       getRowClassName={({ row }) => getRowClassName(row.type, row.depth)}
       getCellClassName={(params) =>

--- a/src/components/DatasheetEditor.tsx
+++ b/src/components/DatasheetEditor.tsx
@@ -232,11 +232,13 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
   const initialValue = useRef(value);
   const [key, setKey] = useState(0);
 
+  const canEdit = permissions.edit && !permissions.isLocked;
+
   useLayoutEffect(() => {
-    if (hasFocus && permissions.edit && ref.current) {
+    if (hasFocus && canEdit && ref.current) {
       ref.current.focus();
     }
-  }, [hasFocus, permissions.edit]);
+  }, [hasFocus, canEdit]);
 
   async function handleValueChange(
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -292,10 +294,10 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
         placeholder={placeholder || undefined}
         onKeyDown={handleEscape}
         onValueChange={
-          permissions.edit ? (value) => void handleNumberValueChange(value) : undefined
+          canEdit ? (value) => void handleNumberValueChange(value) : undefined
         }
         defaultValue={typeof initialValue.current === 'number' ? initialValue.current : ''}
-        disabled={!permissions.edit}
+        disabled={!canEdit}
         inputProps={{
           'aria-label': `${row.label} ${field}`,
           decimalScale: getDecimalPrecisionByUnit(row.unit.standard),
@@ -307,9 +309,9 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
         {...commonProps}
         key={key}
         autoComplete="off"
-        disabled={!permissions.edit}
+        disabled={!canEdit}
         onKeyDown={handleEscape}
-        onChange={permissions.edit ? (value) => void handleValueChange(value) : undefined}
+        onChange={canEdit ? (value) => void handleValueChange(value) : undefined}
         fullWidth
         multiline
         maxRows={6}
@@ -321,13 +323,13 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
       />
     );
 
-  if (!permissions.edit) {
+  if (!canEdit) {
+    const tooltipTitle = permissions.isLocked
+      ? 'This plan is locked by an admin. Unlock the plan to make changes.'
+      : 'Request edit access in the NetZeroCities Portal to make changes.';
+
     return (
-      <Tooltip
-        arrow
-        placement="top"
-        title="Request edit access in the NetZeroCities Portal to make changes."
-      >
+      <Tooltip arrow placement="top" title={tooltipTitle}>
         <div>{inputComponent}</div>
       </Tooltip>
     );
@@ -1041,13 +1043,19 @@ function AccordionContentWrapper({
       <AccordionDetails>
         <Box sx={{ height: 400 }}>
           <DataGrid
-            {...(permissions.edit ? singleClickEditProps : {})}
+            key={String(permissions.isLocked)}
+            {...(permissions.edit && !permissions.isLocked ? singleClickEditProps : {})}
             loading={loading}
             slots={{ footer: CustomFooter }}
             slotProps={{ footer: { count: measureCount } }}
             sx={DATA_GRID_SX}
             isCellEditable={(params: GridCellParams<DatasheetEditorRow>) =>
-              !!(permissions.edit && params.colDef.editable && params.row.type !== 'SUM_PERCENT')
+              !!(
+                permissions.edit &&
+                !permissions.isLocked &&
+                params.colDef.editable &&
+                params.row.type !== 'SUM_PERCENT'
+              )
             }
             getRowClassName={(params: GridRowClassNameParams<DatasheetEditorRow>) =>
               getRowClassName(params.row.type, params.row.depth)

--- a/src/components/DeletePlanDialog.tsx
+++ b/src/components/DeletePlanDialog.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useMutation } from '@apollo/client';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Trash } from 'react-bootstrap-icons';
+
+import { DELETE_FRAMEWORK_CONFIG } from '@/queries/framework/delete-framework-config';
+import { GET_FRAMEWORK_CONFIGS } from '@/queries/framework/get-framework-config';
+import type {
+  DeleteFrameworkMutation,
+  DeleteFrameworkMutationVariables,
+} from '@/types/__generated__/graphql';
+
+import { useSnackbar } from './SnackbarProvider';
+
+type Props = {
+  open: boolean;
+  planId: string | null;
+  planName: string | null;
+  onClose: () => void;
+  onSuccess: (deletedId: string) => void;
+};
+
+export function DeletePlanDialog({ open, planId, planName, onClose, onSuccess }: Props) {
+  const [typedName, setTypedName] = useState('');
+  const { setNotification } = useSnackbar();
+
+  const [deletePlan, { loading }] = useMutation<
+    DeleteFrameworkMutation,
+    DeleteFrameworkMutationVariables
+  >(DELETE_FRAMEWORK_CONFIG, {
+    refetchQueries: [GET_FRAMEWORK_CONFIGS],
+  });
+
+  useEffect(() => {
+    if (open) {
+      setTypedName('');
+    }
+  }, [open, planId]);
+
+  const nameMatches = typedName.trim() === (planName ?? '');
+
+  async function handleConfirm() {
+    if (!planId || !nameMatches) {
+      return;
+    }
+
+    try {
+      await deletePlan({ variables: { id: planId } });
+
+      setNotification({
+        message: `"${planName}" was deleted.`,
+        severity: 'success',
+      });
+
+      onSuccess(planId);
+    } catch {
+      setNotification({
+        message: 'Failed to delete the plan. Please try again.',
+        severity: 'error',
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              color: 'error.dark',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Trash size={20} />
+          </Box>
+          <Typography variant="h5" component="span">
+            Delete "{planName}"?
+          </Typography>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          This plan and all its collected data will be permanently deleted.{' '}
+          <Box component="span" sx={{ fontWeight: 700 }}>
+            This action can't be undone.
+          </Box>
+        </Typography>
+
+        <Alert severity="warning" icon={false} sx={{ mb: 2 }}>
+          <Typography variant="body2" fontWeight={700} gutterBottom>
+            You will lose:
+          </Typography>
+          <Box component="ul" sx={{ pl: 2 }}>
+            <li>All baseline and assumption data</li>
+            <li>Outcomes dashboard projections</li>
+          </Box>
+        </Alert>
+
+        <Typography variant="body2" color="text.secondary">
+          To confirm, type the plan name:{' '}
+          <Box
+            component="code"
+            sx={{
+              bgcolor: 'grey.200',
+              px: 1,
+              py: 0.25,
+              borderRadius: 1,
+            }}
+          >
+            {planName}
+          </Box>
+        </Typography>
+        <TextField
+          autoFocus
+          fullWidth
+          size="small"
+          value={typedName}
+          onChange={(e) => setTypedName(e.target.value)}
+          placeholder={planName ?? undefined}
+          sx={{ mt: 1 }}
+          focused={nameMatches || undefined}
+        />
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button variant="text" color="primary" onClick={onClose}>
+          Cancel
+        </Button>
+
+        <Button
+          variant="contained"
+          color="error"
+          disabled={!nameMatches || loading}
+          startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <Trash size={16} />}
+          onClick={() => void handleConfirm()}
+        >
+          Delete plan
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/InstanceControlBar.tsx
+++ b/src/components/InstanceControlBar.tsx
@@ -241,15 +241,18 @@ export function InstanceControlBar() {
                 onInstanceChange={setSelectedPlanId}
               />
             )}
-            {!permissions.isLoading && permissions.isFrameworkAdmin && plan && (
+            {!permissions.isLoading && plan && (permissions.create || permissions.isAdmin) && (
               <PlanActionsMenu
                 planId={plan.id}
                 planName={plan.organizationName ?? ''}
                 isLocked={plan.locked ?? false}
+                canCreate={permissions.create}
+                isAdmin={permissions.isAdmin}
+                onCreateClick={() => setIsAddModalOpen(true)}
                 onDeleteClick={() => setIsDeleteDialogOpen(true)}
               />
             )}
-            {!permissions.isLoading && (
+            {!permissions.isLoading && (!plan || (!permissions.create && !permissions.isAdmin)) && (
               <>
                 {permissions.create ? (
                   <Button onClick={() => setIsAddModalOpen(true)} variant="outlined">

--- a/src/components/InstanceControlBar.tsx
+++ b/src/components/InstanceControlBar.tsx
@@ -36,11 +36,10 @@ import { areHistoricalYearsAvailable } from '@/utils/historical-data';
 
 import type { NewPlanData } from './AddPlanDialog';
 import { AddPlanDialog } from './AddPlanDialog';
+import { DeletePlanDialog } from './DeletePlanDialog';
+import { PlanActionsMenu } from './PlanActionsMenu';
 import { SUPPORT_FORM_URL } from './links';
-import {
-  usePlans,
-  useSuspenseSelectedPlanConfig,
-} from './providers/SelectedPlanProvider';
+import { usePlans, useSuspenseSelectedPlanConfig } from './providers/SelectedPlanProvider';
 
 function isTestInstance(name: string) {
   // Note that this is a best guess of test instances until we have a better way to identify them
@@ -87,15 +86,11 @@ function InstanceSelector({
       );
 
   const firstTestInstance = sortTestInstancesLast
-    ? sortedInstances.findIndex((instance) =>
-        isTestInstance(instance.organizationName ?? '')
-      )
+    ? sortedInstances.findIndex((instance) => isTestInstance(instance.organizationName ?? ''))
     : -1;
 
   function handleChange(e: SelectChangeEvent<string>) {
-    const instance = instances.find(
-      (instance) => instance.id === e.target.value
-    );
+    const instance = instances.find((instance) => instance.id === e.target.value);
 
     if (instance) {
       onInstanceChange(instance.id);
@@ -136,9 +131,7 @@ function getNavStyles(isActive: boolean): SxProps<Theme> {
     borderStyle: 'solid',
     borderBottomWidth: isActive ? 2 : 0,
     fontWeight: (theme) =>
-      isActive
-        ? theme.typography.fontWeightBold
-        : theme.typography.fontWeightRegular,
+      isActive ? theme.typography.fontWeightBold : theme.typography.fontWeightRegular,
     '&:hover': {
       borderBottomWidth: 2,
     },
@@ -147,8 +140,8 @@ function getNavStyles(isActive: boolean): SxProps<Theme> {
 
 export function InstanceControlBar() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const [isRequestEditTooltipOpen, setIsRequestEditTooltipOpen] =
-    useState(true); // Initially true, but will only be shown if the user has no create permissions
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isRequestEditTooltipOpen, setIsRequestEditTooltipOpen] = useState(true); // Initially true, but will only be shown if the user has no create permissions
 
   const permissions = usePermissions();
 
@@ -175,10 +168,7 @@ export function InstanceControlBar() {
           targetYear: Number(data.targetYear),
           slug: kebabCase(data.planName),
           population: Number(data.population),
-          renewableMix:
-            data.renewableElectricityMix === 'high'
-              ? LowHigh.High
-              : LowHigh.Low,
+          renewableMix: data.renewableElectricityMix === 'high' ? LowHigh.High : LowHigh.Low,
           temperature: data.climate === 'warm' ? LowHigh.High : LowHigh.Low,
         },
       });
@@ -192,6 +182,16 @@ export function InstanceControlBar() {
       setIsAddModalOpen(false);
     } catch (error) {
       console.error('Error creating framework config:', error);
+    }
+  }
+
+  function handleDeleteSuccess(deletedId: string) {
+    setIsDeleteDialogOpen(false);
+
+    const remainingInstances = instanceConfigs.filter((c) => c.id !== deletedId);
+
+    if (remainingInstances[0]) {
+      setSelectedPlanId(remainingInstances[0].id);
     }
   }
 
@@ -218,12 +218,7 @@ export function InstanceControlBar() {
         >
           {!!plan && areHistoricalYearsAvailable(plan.baselineYear) && (
             <Stack direction="row" spacing={2}>
-              <MuiLink
-                href="/"
-                component={Link}
-                underline="none"
-                sx={getNavStyles(isActive('/'))}
-              >
+              <MuiLink href="/" component={Link} underline="none" sx={getNavStyles(isActive('/'))}>
                 Overview
               </MuiLink>
 
@@ -238,12 +233,7 @@ export function InstanceControlBar() {
             </Stack>
           )}
 
-          <Stack
-            direction="row"
-            justifyContent="flex-end"
-            ml="auto"
-            spacing={2}
-          >
+          <Stack direction="row" justifyContent="flex-end" ml="auto" spacing={1}>
             {hasMultipleInstances && plan?.id && (
               <InstanceSelector
                 selectedInstanceId={plan.id}
@@ -251,13 +241,18 @@ export function InstanceControlBar() {
                 onInstanceChange={setSelectedPlanId}
               />
             )}
+            {!permissions.isLoading && permissions.isFrameworkAdmin && plan && (
+              <PlanActionsMenu
+                planId={plan.id}
+                planName={plan.organizationName ?? ''}
+                isLocked={plan.locked ?? false}
+                onDeleteClick={() => setIsDeleteDialogOpen(true)}
+              />
+            )}
             {!permissions.isLoading && (
               <>
                 {permissions.create ? (
-                  <Button
-                    onClick={() => setIsAddModalOpen(true)}
-                    variant="outlined"
-                  >
+                  <Button onClick={() => setIsAddModalOpen(true)} variant="outlined">
                     Create new plan
                   </Button>
                 ) : (
@@ -269,8 +264,8 @@ export function InstanceControlBar() {
                     arrow
                     title={
                       <Typography variant="body2">
-                        You don't have permission to create a plan. To request
-                        edit access, please fill out{' '}
+                        You don't have permission to create a plan. To request edit access, please
+                        fill out{' '}
                         <MuiLink
                           target="_blank"
                           rel="noopener noreferrer"
@@ -284,11 +279,7 @@ export function InstanceControlBar() {
                     }
                   >
                     <Box sx={{ display: 'flex', alignItems: 'stretch' }}>
-                      <Button
-                        variant="outlined"
-                        disabled
-                        startIcon={<Lock size={18} />}
-                      >
+                      <Button variant="outlined" disabled startIcon={<Lock size={18} />}>
                         Create new plan
                       </Button>
                     </Box>
@@ -306,6 +297,14 @@ export function InstanceControlBar() {
         onSubmit={handleSubmit}
         loading={loading}
         error={error}
+      />
+
+      <DeletePlanDialog
+        open={isDeleteDialogOpen}
+        planId={plan?.id ?? null}
+        planName={plan?.organizationName ?? null}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onSuccess={handleDeleteSuccess}
       />
     </>
   );

--- a/src/components/InstanceControlBar.tsx
+++ b/src/components/InstanceControlBar.tsx
@@ -244,8 +244,9 @@ export function InstanceControlBar() {
             {!permissions.isLoading && plan && (permissions.create || permissions.isAdmin) && (
               <PlanActionsMenu
                 planId={plan.id}
+                instanceIdentifier={plan.instanceIdentifier}
                 planName={plan.organizationName ?? ''}
-                isLocked={plan.locked ?? false}
+                isLocked={plan.isLocked ?? false}
                 canCreate={permissions.create}
                 isAdmin={permissions.isAdmin}
                 onCreateClick={() => setIsAddModalOpen(true)}

--- a/src/components/PlanActionsMenu.tsx
+++ b/src/components/PlanActionsMenu.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useMutation } from '@apollo/client';
+import {
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import { Gear, Lock, ThreeDots, Trash, Unlock } from 'react-bootstrap-icons';
+
+import {
+  LOCK_FRAMEWORK_CONFIG,
+  type LockFrameworkConfigMutation,
+  type LockFrameworkConfigMutationVariables,
+} from '@/queries/framework/lock-framework-config';
+
+import { useSnackbar } from './SnackbarProvider';
+
+type Props = {
+  planId: string;
+  planName: string;
+  isLocked: boolean;
+  onDeleteClick: () => void;
+};
+
+export function PlanActionsMenu({ planId, planName, isLocked, onDeleteClick }: Props) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isOpen = !!anchorEl;
+  const { setNotification } = useSnackbar();
+
+  // TODO: Update this when the backend is ready
+  const [lockPlan, { loading }] = useMutation<
+    LockFrameworkConfigMutation,
+    LockFrameworkConfigMutationVariables
+  >(LOCK_FRAMEWORK_CONFIG);
+
+  function handleOpen(e: React.MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(e.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  async function handleLockToggle() {
+    handleClose();
+    try {
+      await lockPlan({ variables: { id: planId, locked: !isLocked } });
+      setNotification({
+        message: isLocked
+          ? `"${planName}" unlocked — editing enabled.`
+          : `"${planName}" locked — editing disabled.`,
+        severity: 'success',
+      });
+    } catch {
+      setNotification({
+        message: 'Failed to update plan lock status. Please try again.',
+        severity: 'error',
+      });
+    }
+  }
+
+  function handleDeleteClick() {
+    handleClose();
+    onDeleteClick();
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <IconButton color="inherit" onClick={handleOpen} disabled={loading}>
+        <ThreeDots size={22} />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { minWidth: 240, mt: 0.75 } } }}
+      >
+        <MenuItem onClick={() => void handleLockToggle()}>
+          <ListItemIcon>{isLocked ? <Unlock size={16} /> : <Lock size={16} />}</ListItemIcon>
+          <ListItemText
+            primary={isLocked ? 'Unlock plan' : 'Lock plan'}
+            secondary={isLocked ? 'Allow edits again' : 'Prevent edits until unlocked'}
+          />
+        </MenuItem>
+
+        <Divider />
+
+        <MenuItem onClick={handleDeleteClick} sx={{ color: 'error.dark' }}>
+          <ListItemIcon sx={{ color: 'error.dark' }}>
+            <Trash size={16} />
+          </ListItemIcon>
+          <ListItemText
+            primary="Delete plan"
+            secondary="Permanently remove this plan"
+            slotProps={{ secondary: { color: 'error.dark', sx: { opacity: 0.8 } } }}
+          />
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+}

--- a/src/components/PlanActionsMenu.tsx
+++ b/src/components/PlanActionsMenu.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import {
   Box,
-  Button,
   Divider,
   IconButton,
   ListItemIcon,
@@ -13,7 +12,7 @@ import {
   Menu,
   MenuItem,
 } from '@mui/material';
-import { Gear, Lock, ThreeDots, Trash, Unlock } from 'react-bootstrap-icons';
+import { FileEarmarkPlus, Lock, ThreeDots, Trash, Unlock } from 'react-bootstrap-icons';
 
 import {
   LOCK_FRAMEWORK_CONFIG,
@@ -27,10 +26,21 @@ type Props = {
   planId: string;
   planName: string;
   isLocked: boolean;
+  canCreate: boolean;
+  isAdmin: boolean;
+  onCreateClick: () => void;
   onDeleteClick: () => void;
 };
 
-export function PlanActionsMenu({ planId, planName, isLocked, onDeleteClick }: Props) {
+export function PlanActionsMenu({
+  planId,
+  planName,
+  isLocked,
+  canCreate,
+  isAdmin,
+  onCreateClick,
+  onDeleteClick,
+}: Props) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const isOpen = !!anchorEl;
   const { setNotification } = useSnackbar();
@@ -72,6 +82,11 @@ export function PlanActionsMenu({ planId, planName, isLocked, onDeleteClick }: P
     onDeleteClick();
   }
 
+  function handleCreateClick() {
+    handleClose();
+    onCreateClick();
+  }
+
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <IconButton color="inherit" onClick={handleOpen} disabled={loading}>
@@ -85,26 +100,40 @@ export function PlanActionsMenu({ planId, planName, isLocked, onDeleteClick }: P
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         slotProps={{ paper: { sx: { minWidth: 240, mt: 0.75 } } }}
       >
-        <MenuItem onClick={() => void handleLockToggle()}>
-          <ListItemIcon>{isLocked ? <Unlock size={16} /> : <Lock size={16} />}</ListItemIcon>
-          <ListItemText
-            primary={isLocked ? 'Unlock plan' : 'Lock plan'}
-            secondary={isLocked ? 'Allow edits again' : 'Prevent edits until unlocked'}
-          />
-        </MenuItem>
+        {canCreate && (
+          <MenuItem onClick={handleCreateClick}>
+            <ListItemIcon>
+              <FileEarmarkPlus size={16} />
+            </ListItemIcon>
+            <ListItemText primary="Create new plan" />
+          </MenuItem>
+        )}
 
-        <Divider />
+        {canCreate && isAdmin && <Divider />}
 
-        <MenuItem onClick={handleDeleteClick} sx={{ color: 'error.dark' }}>
-          <ListItemIcon sx={{ color: 'error.dark' }}>
-            <Trash size={16} />
-          </ListItemIcon>
-          <ListItemText
-            primary="Delete plan"
-            secondary="Permanently remove this plan"
-            slotProps={{ secondary: { color: 'error.dark', sx: { opacity: 0.8 } } }}
-          />
-        </MenuItem>
+        {isAdmin && (
+          <MenuItem onClick={() => void handleLockToggle()}>
+            <ListItemIcon>{isLocked ? <Unlock size={16} /> : <Lock size={16} />}</ListItemIcon>
+            <ListItemText
+              primary={isLocked ? 'Unlock plan' : 'Lock plan'}
+              secondary={isLocked ? 'Allow edits again' : 'Prevent edits until unlocked'}
+            />
+          </MenuItem>
+        )}
+
+        {isAdmin && <Divider />}
+
+        {isAdmin && (
+          <MenuItem onClick={handleDeleteClick} sx={{ color: 'error.dark' }}>
+            <ListItemIcon sx={{ color: 'error.dark' }}>
+              <Trash size={16} />
+            </ListItemIcon>
+            <ListItemText
+              primary="Delete plan"
+              slotProps={{ secondary: { color: 'error.dark', sx: { opacity: 0.8 } } }}
+            />
+          </MenuItem>
+        )}
       </Menu>
     </Box>
   );

--- a/src/components/PlanActionsMenu.tsx
+++ b/src/components/PlanActionsMenu.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import { useMutation } from '@apollo/client';
 import {
   Box,
   Divider,
@@ -14,16 +13,13 @@ import {
 } from '@mui/material';
 import { FileEarmarkPlus, Lock, ThreeDots, Trash, Unlock } from 'react-bootstrap-icons';
 
-import {
-  LOCK_FRAMEWORK_CONFIG,
-  type LockFrameworkConfigMutation,
-  type LockFrameworkConfigMutationVariables,
-} from '@/queries/framework/lock-framework-config';
+import { useSetInstanceLocked } from '@/queries/framework/lock-framework-config';
 
 import { useSnackbar } from './SnackbarProvider';
 
 type Props = {
   planId: string;
+  instanceIdentifier?: string;
   planName: string;
   isLocked: boolean;
   canCreate: boolean;
@@ -34,6 +30,7 @@ type Props = {
 
 export function PlanActionsMenu({
   planId,
+  instanceIdentifier,
   planName,
   isLocked,
   canCreate,
@@ -45,11 +42,7 @@ export function PlanActionsMenu({
   const isOpen = !!anchorEl;
   const { setNotification } = useSnackbar();
 
-  // TODO: Update this when the backend is ready
-  const [lockPlan, { loading }] = useMutation<
-    LockFrameworkConfigMutation,
-    LockFrameworkConfigMutationVariables
-  >(LOCK_FRAMEWORK_CONFIG);
+  const [lockPlan, { loading }] = useSetInstanceLocked(planId);
 
   function handleOpen(e: React.MouseEvent<HTMLButtonElement>) {
     setAnchorEl(e.currentTarget);
@@ -59,10 +52,12 @@ export function PlanActionsMenu({
     setAnchorEl(null);
   }
 
-  async function handleLockToggle() {
+  async function handleLockToggle(instanceIdentifier: string) {
     handleClose();
+
     try {
-      await lockPlan({ variables: { id: planId, locked: !isLocked } });
+      await lockPlan({ variables: { instanceId: instanceIdentifier, isLocked: !isLocked } });
+
       setNotification({
         message: isLocked
           ? `"${planName}" unlocked — editing enabled.`
@@ -111,8 +106,8 @@ export function PlanActionsMenu({
 
         {canCreate && isAdmin && <Divider />}
 
-        {isAdmin && (
-          <MenuItem onClick={() => void handleLockToggle()}>
+        {isAdmin && instanceIdentifier && (
+          <MenuItem onClick={() => void handleLockToggle(instanceIdentifier)}>
             <ListItemIcon>{isLocked ? <Unlock size={16} /> : <Lock size={16} />}</ListItemIcon>
             <ListItemText
               primary={isLocked ? 'Unlock plan' : 'Lock plan'}

--- a/src/components/__tests__/DeletePlanDialog.test.tsx
+++ b/src/components/__tests__/DeletePlanDialog.test.tsx
@@ -1,0 +1,159 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@/utils/tests';
+import { DeletePlanDialog } from '../DeletePlanDialog';
+import { DELETE_FRAMEWORK_CONFIG } from '@/queries/framework/delete-framework-config';
+import { GET_FRAMEWORK_CONFIGS } from '@/queries/framework/get-framework-config';
+
+const defaultProps = {
+  open: true,
+  planId: 'plan-1',
+  planName: 'Test City',
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+const refetchMock = {
+  request: { query: GET_FRAMEWORK_CONFIGS },
+  result: { data: { framework: null } },
+};
+
+function renderDialog(
+  props: Partial<typeof defaultProps> = {},
+  mocks: Parameters<typeof render>[1]['mocks'] = []
+) {
+  return render(<DeletePlanDialog {...defaultProps} {...props} />, { mocks });
+}
+
+function getDeleteButton() {
+  return screen.getByRole('button', { name: /delete plan/i });
+}
+
+function getInput() {
+  return screen.getByRole('textbox');
+}
+
+describe('DeletePlanDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('renders the plan name in the dialog title', () => {
+      renderDialog();
+      expect(screen.getByText(/Delete "Test City"\?/)).toBeInTheDocument();
+    });
+
+    it('has an empty input field on open', () => {
+      renderDialog();
+      expect(getInput()).toHaveValue('');
+    });
+
+    it('has the Delete button disabled on open', () => {
+      renderDialog();
+      expect(getDeleteButton()).toBeDisabled();
+    });
+  });
+
+  describe('name-matching confirm logic', () => {
+    it('keeps Delete button disabled when typed value does not match plan name', () => {
+      renderDialog();
+      fireEvent.change(getInput(), { target: { value: 'wrong name' } });
+      expect(getDeleteButton()).toBeDisabled();
+    });
+
+    it('enables Delete button when typed value exactly matches plan name', () => {
+      renderDialog();
+      fireEvent.change(getInput(), { target: { value: 'Test City' } });
+      expect(getDeleteButton()).not.toBeDisabled();
+    });
+
+    it('enables Delete button when typed value matches after trimming whitespace', () => {
+      renderDialog();
+      fireEvent.change(getInput(), { target: { value: 'Test City ' } });
+      expect(getDeleteButton()).not.toBeDisabled();
+    });
+
+    it('keeps Delete button disabled when typed value differs only by case', () => {
+      renderDialog();
+      fireEvent.change(getInput(), { target: { value: 'test city' } });
+      expect(getDeleteButton()).toBeDisabled();
+    });
+  });
+
+  describe('reset behaviour', () => {
+    it('clears the typed text when the dialog is closed and reopened', () => {
+      const { rerender } = renderDialog();
+      fireEvent.change(getInput(), { target: { value: 'Test City' } });
+      expect(getInput()).toHaveValue('Test City');
+
+      rerender(
+        <DeletePlanDialog {...defaultProps} open={false} />,
+      );
+      rerender(
+        <DeletePlanDialog {...defaultProps} open={true} />,
+      );
+
+      expect(getInput()).toHaveValue('');
+    });
+  });
+
+  describe('delete mutation', () => {
+    const deleteMock = {
+      request: {
+        query: DELETE_FRAMEWORK_CONFIG,
+        variables: { id: 'plan-1' },
+      },
+      result: {
+        data: { deleteFrameworkConfig: { ok: true } },
+      },
+    };
+
+    it('calls onSuccess with the plan id and shows success snackbar on successful deletion', async () => {
+      const onSuccess = jest.fn();
+      renderDialog({ onSuccess }, [deleteMock, refetchMock]);
+      fireEvent.change(getInput(), { target: { value: 'Test City' } });
+      fireEvent.click(getDeleteButton());
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith('plan-1');
+        expect(screen.getByText(/"Test City" was deleted\./)).toBeInTheDocument();
+      });
+    });
+
+    it('does not call onSuccess and shows error snackbar when mutation fails', async () => {
+      const onSuccess = jest.fn();
+      const errorMock = {
+        request: {
+          query: DELETE_FRAMEWORK_CONFIG,
+          variables: { id: 'plan-1' },
+        },
+        error: new Error('Network error'),
+      };
+      renderDialog({ onSuccess }, [errorMock]);
+      fireEvent.change(getInput(), { target: { value: 'Test City' } });
+      fireEvent.click(getDeleteButton());
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to delete the plan. Please try again.')
+        ).toBeInTheDocument();
+      });
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('disables the Delete button while the mutation is in-flight', async () => {
+      const delayedMock = { ...deleteMock, delay: 200 };
+      renderDialog({}, [delayedMock, refetchMock]);
+      fireEvent.change(getInput(), { target: { value: 'Test City' } });
+      fireEvent.click(getDeleteButton());
+      await waitFor(() => {
+        expect(getDeleteButton()).toBeDisabled();
+      });
+    });
+  });
+
+  describe('null safety', () => {
+    it('renders without crashing when planId and planName are null (dialog closed)', () => {
+      renderDialog({ open: false, planId: null, planName: null });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/PlanActionsMenu.test.tsx
+++ b/src/components/__tests__/PlanActionsMenu.test.tsx
@@ -1,0 +1,198 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@/utils/tests';
+import { PlanActionsMenu } from '../PlanActionsMenu';
+import { SET_INSTANCE_LOCKED } from '@/queries/framework/lock-framework-config';
+
+const defaultProps = {
+  planId: 'plan-1',
+  instanceIdentifier: 'inst-1',
+  planName: 'Test City',
+  isLocked: false,
+  canCreate: false,
+  isAdmin: false,
+  onCreateClick: jest.fn(),
+  onDeleteClick: jest.fn(),
+};
+
+function renderMenu(
+  props: Partial<typeof defaultProps> = {},
+  mocks: Parameters<typeof render>[1]['mocks'] = []
+) {
+  return render(<PlanActionsMenu {...defaultProps} {...props} />, { mocks });
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('button'));
+}
+
+describe('PlanActionsMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('menu visibility', () => {
+    it('renders the three-dot button and menu is closed initially', () => {
+      renderMenu();
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('shows "Create new plan" but hides lock and delete when canCreate=true, isAdmin=false', () => {
+      renderMenu({ canCreate: true });
+      openMenu();
+      expect(screen.getByText('Create new plan')).toBeInTheDocument();
+      expect(screen.queryByText(/Lock plan|Unlock plan/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Delete plan')).not.toBeInTheDocument();
+    });
+
+    it('hides "Create new plan" and shows lock and delete when canCreate=false, isAdmin=true', () => {
+      renderMenu({ isAdmin: true });
+      openMenu();
+      expect(screen.queryByText('Create new plan')).not.toBeInTheDocument();
+      expect(screen.getByText('Lock plan')).toBeInTheDocument();
+      expect(screen.getByText('Delete plan')).toBeInTheDocument();
+    });
+
+    it('shows all three items when canCreate=true, isAdmin=true', () => {
+      renderMenu({ canCreate: true, isAdmin: true });
+      openMenu();
+      expect(screen.getByText('Create new plan')).toBeInTheDocument();
+      expect(screen.getByText('Lock plan')).toBeInTheDocument();
+      expect(screen.getByText('Delete plan')).toBeInTheDocument();
+    });
+
+    it('shows no menu items when canCreate=false, isAdmin=false', () => {
+      renderMenu();
+      openMenu();
+      expect(screen.queryByText('Create new plan')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Lock plan|Unlock plan/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Delete plan')).not.toBeInTheDocument();
+    });
+
+    it('hides lock item but shows delete when isAdmin=true and instanceIdentifier is undefined', () => {
+      renderMenu({ isAdmin: true, instanceIdentifier: undefined });
+      openMenu();
+      expect(screen.queryByText(/Lock plan|Unlock plan/)).not.toBeInTheDocument();
+      expect(screen.getByText('Delete plan')).toBeInTheDocument();
+    });
+  });
+
+  describe('lock item label', () => {
+    it('shows "Lock plan" when isLocked=false', () => {
+      renderMenu({ isAdmin: true, isLocked: false });
+      openMenu();
+      expect(screen.getByText('Lock plan')).toBeInTheDocument();
+    });
+
+    it('shows "Unlock plan" when isLocked=true', () => {
+      renderMenu({ isAdmin: true, isLocked: true });
+      openMenu();
+      expect(screen.getByText('Unlock plan')).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('opens the menu when the three-dot button is clicked', () => {
+      renderMenu({ canCreate: true });
+      openMenu();
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('calls onCreateClick and closes menu when "Create new plan" is clicked', () => {
+      const onCreateClick = jest.fn();
+      renderMenu({ canCreate: true, onCreateClick });
+      openMenu();
+      fireEvent.click(screen.getByText('Create new plan'));
+      expect(onCreateClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('calls onDeleteClick and closes menu when "Delete plan" is clicked', () => {
+      const onDeleteClick = jest.fn();
+      renderMenu({ isAdmin: true, onDeleteClick });
+      openMenu();
+      fireEvent.click(screen.getByText('Delete plan'));
+      expect(onDeleteClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('closes the menu on Escape without calling any callback', () => {
+      const onCreateClick = jest.fn();
+      const onDeleteClick = jest.fn();
+      renderMenu({ canCreate: true, isAdmin: true, onCreateClick, onDeleteClick });
+      openMenu();
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+      expect(onCreateClick).not.toHaveBeenCalled();
+      expect(onDeleteClick).not.toHaveBeenCalled();
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('lock mutation', () => {
+    const lockMock = {
+      request: {
+        query: SET_INSTANCE_LOCKED,
+        variables: { instanceId: 'inst-1', isLocked: true },
+      },
+      result: {
+        data: { setInstanceLocked: { __typename: 'SetInstanceLockedResult' } },
+      },
+    };
+
+    const unlockMock = {
+      request: {
+        query: SET_INSTANCE_LOCKED,
+        variables: { instanceId: 'inst-1', isLocked: false },
+      },
+      result: {
+        data: { setInstanceLocked: { __typename: 'SetInstanceLockedResult' } },
+      },
+    };
+
+    it('fires SetInstanceLocked with isLocked:true and shows success snackbar on lock', async () => {
+      renderMenu({ isAdmin: true, isLocked: false }, [lockMock]);
+      openMenu();
+      fireEvent.click(screen.getByText('Lock plan'));
+      await waitFor(() => {
+        expect(screen.getByText(/"Test City" locked/)).toBeInTheDocument();
+      });
+    });
+
+    it('fires SetInstanceLocked with isLocked:false and shows success snackbar on unlock', async () => {
+      renderMenu({ isAdmin: true, isLocked: true }, [unlockMock]);
+      openMenu();
+      fireEvent.click(screen.getByText('Unlock plan'));
+      await waitFor(() => {
+        expect(screen.getByText(/"Test City" unlocked/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows error snackbar when the mutation fails', async () => {
+      const errorMock = {
+        request: {
+          query: SET_INSTANCE_LOCKED,
+          variables: { instanceId: 'inst-1', isLocked: true },
+        },
+        error: new Error('Network error'),
+      };
+      renderMenu({ isAdmin: true, isLocked: false }, [errorMock]);
+      openMenu();
+      fireEvent.click(screen.getByText('Lock plan'));
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to update plan lock status. Please try again.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('disables the three-dot button while the mutation is in-flight', async () => {
+      const delayedMock = { ...lockMock, delay: 200 };
+      renderMenu({ isAdmin: true, isLocked: false }, [delayedMock]);
+      openMenu();
+      fireEvent.click(screen.getByText('Lock plan'));
+      await waitFor(() => {
+        expect(screen.getByRole('button')).toBeDisabled();
+      });
+    });
+  });
+});

--- a/src/components/providers/SelectedPlanProvider.tsx
+++ b/src/components/providers/SelectedPlanProvider.tsx
@@ -65,6 +65,7 @@ export function SelectedPlanProvider({ children, plan: initialPlan }: Props) {
   }
 
   const planCount = data?.framework?.configs.length ?? 0;
+
   if (planCount === 0 && initialPlan) {
     logger.warn('No plans found, removing plan cookie');
     Cookies.remove(PLAN_COOKIE_KEY);
@@ -72,6 +73,7 @@ export function SelectedPlanProvider({ children, plan: initialPlan }: Props) {
   }
 
   const [planId, setPlanId] = useState<string | undefined>(initialPlan);
+
   const selectedPlan = planId
     ? data?.framework?.configs.find((config) => config.id === planId)
     : undefined;

--- a/src/components/providers/SelectedPlanProvider.tsx
+++ b/src/components/providers/SelectedPlanProvider.tsx
@@ -24,7 +24,7 @@ type SelectedPlanContextType = {
   setSelectedPlanId: (plan: string | undefined) => void;
 };
 
-const SelectedPlanContext = createContext<SelectedPlanContextType>({
+export const SelectedPlanContext = createContext<SelectedPlanContextType>({
   selectedPlanId: undefined,
   selectedPlan: null,
   allPlans: null,

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,1 +1,2 @@
 export const FRAMEWORK_ADMIN_ROLE = 'framework-admin';
+export const INSTANCE_ADMIN_ROLE = 'instance-admin';

--- a/src/hooks/__tests__/use-permissions.test.tsx
+++ b/src/hooks/__tests__/use-permissions.test.tsx
@@ -1,0 +1,192 @@
+import '@testing-library/jest-dom';
+
+// These packages use ESM-only builds that Jest (CJS mode) cannot parse.
+// Mock the whole module to keep the import chain CJS-compatible.
+jest.mock('next-auth/react', () => ({ useSession: jest.fn(() => ({ status: 'authenticated' })) }));
+jest.mock('@/components/providers/SelectedPlanProvider', () => ({ usePlans: jest.fn() }));
+
+import type { ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import type { ProfileQuery } from '@/types/__generated__/graphql';
+import { UserProfileContext, usePermissions } from '@/hooks/use-user-profile';
+import { usePlans } from '@/components/providers/SelectedPlanProvider';
+
+const mockUsePlans = usePlans as jest.MockedFunction<typeof usePlans>;
+
+type SelectedPlan = NonNullable<ReturnType<typeof usePlans>['selectedPlan']>;
+
+function makePlan(overrides: Partial<SelectedPlan> = {}): SelectedPlan {
+  return {
+    __typename: 'FrameworkConfig',
+    id: 'plan-1',
+    organizationName: 'Test City',
+    baselineYear: 2020,
+    targetYear: 2030,
+    viewUrl: null,
+    resultsDownloadUrl: null,
+    instanceIdentifier: 'inst-1',
+    isLocked: false,
+    ...overrides,
+  };
+}
+
+function makeProfile(overrides: {
+  change?: boolean;
+  creatableRelatedModels?: string[];
+  userRoles?: string[];
+  configs?: Array<{ id: string; change?: boolean; delete?: boolean }>;
+} = {}): ProfileQuery {
+  return {
+    __typename: 'Query',
+    me: null,
+    framework: {
+      __typename: 'Framework',
+      id: 'fw-1',
+      userRoles: overrides.userRoles ?? [],
+      userPermissions: {
+        __typename: 'UserPermissions',
+        change: overrides.change ?? false,
+        creatableRelatedModels: overrides.creatableRelatedModels ?? [],
+      },
+      configs: (overrides.configs ?? []).map((c) => ({
+        __typename: 'FrameworkConfig' as const,
+        id: c.id,
+        userPermissions: {
+          __typename: 'UserPermissions',
+          view: true,
+          change: c.change ?? false,
+          delete: c.delete ?? false,
+          actions: [],
+          creatableRelatedModels: [],
+          otherPermissions: [],
+        },
+      })),
+    },
+  };
+}
+
+function makeWrapper(loading = false, profile: ProfileQuery | null = null) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <UserProfileContext.Provider value={{ loading, profile }}>
+        {children}
+      </UserProfileContext.Provider>
+    );
+  };
+}
+
+describe('usePermissions', () => {
+  beforeEach(() => {
+    mockUsePlans.mockReturnValue({
+      selectedPlanId: undefined,
+      selectedPlan: null,
+      allPlans: null,
+      setSelectedPlanId: jest.fn(),
+    });
+  });
+
+  describe('edit permission', () => {
+    it('returns true when framework.userPermissions.change is true, even if plan is locked', () => {
+      const plan = makePlan({ isLocked: true });
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ change: true })),
+      });
+      expect(result.current.edit).toBe(true);
+    });
+
+    it('returns false when framework.userPermissions.change is false', () => {
+      const plan = makePlan();
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ change: false })),
+      });
+      expect(result.current.edit).toBe(false);
+    });
+  });
+
+  describe('isLocked', () => {
+    it('returns true when the selected plan has isLocked:true', () => {
+      const plan = makePlan({ isLocked: true });
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile()),
+      });
+      expect(result.current.isLocked).toBe(true);
+    });
+
+    it('returns false when the selected plan has isLocked:false', () => {
+      const plan = makePlan({ isLocked: false });
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile()),
+      });
+      expect(result.current.isLocked).toBe(false);
+    });
+
+    it('returns false when there is no selected plan', () => {
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile()),
+      });
+      expect(result.current.isLocked).toBe(false);
+    });
+  });
+
+  describe('isAdmin', () => {
+    it('returns true for a framework-admin user', () => {
+      const plan = makePlan();
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ userRoles: ['framework-admin'] })),
+      });
+      expect(result.current.isAdmin).toBe(true);
+    });
+
+    it('returns true for a user with config-level delete permission (instance-admin)', () => {
+      const plan = makePlan();
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ configs: [{ id: 'plan-1', delete: true }] })),
+      });
+      expect(result.current.isAdmin).toBe(true);
+    });
+
+    it('returns false when neither framework-admin nor config delete permission', () => {
+      const plan = makePlan();
+      mockUsePlans.mockReturnValue({ selectedPlanId: 'plan-1', selectedPlan: plan, allPlans: [plan], setSelectedPlanId: jest.fn() });
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ configs: [{ id: 'plan-1', delete: false }] })),
+      });
+      expect(result.current.isAdmin).toBe(false);
+    });
+  });
+
+  describe('isLoading', () => {
+    it('returns isLoading:true and all permission flags false while profile is loading', () => {
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(true, null),
+      });
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.edit).toBe(false);
+      expect(result.current.create).toBe(false);
+      expect(result.current.isAdmin).toBe(false);
+      expect(result.current.delete).toBe(false);
+    });
+  });
+
+  describe('create permission', () => {
+    it('returns true when "FrameworkConfig" is in creatableRelatedModels', () => {
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ creatableRelatedModels: ['FrameworkConfig'] })),
+      });
+      expect(result.current.create).toBe(true);
+    });
+
+    it('returns false when "FrameworkConfig" is not in creatableRelatedModels', () => {
+      const { result } = renderHook(() => usePermissions(), {
+        wrapper: makeWrapper(false, makeProfile({ creatableRelatedModels: [] })),
+      });
+      expect(result.current.create).toBe(false);
+    });
+  });
+});

--- a/src/hooks/use-user-profile.tsx
+++ b/src/hooks/use-user-profile.tsx
@@ -94,7 +94,7 @@ export function usePermissions() {
       )) ??
     false;
 
-  const isLocked = selectedPlan?.locked ?? false;
+  const isLocked = selectedPlan?.isLocked ?? false;
   const isFrameworkAdmin = !!profile?.framework?.userRoles?.includes(FRAMEWORK_ADMIN_ROLE);
   const canDelete = frameworkConfigPermissions?.delete ?? false;
 
@@ -104,7 +104,7 @@ export function usePermissions() {
     isAdmin: isFrameworkAdmin || canDelete,
     isLoading: loading,
     create: canCreate,
-    edit: (frameworkConfigPermissions?.change ?? false) && !isLocked,
+    edit: frameworkConfigPermissions?.change ?? false,
     delete: canDelete,
     isLocked,
   };

--- a/src/hooks/use-user-profile.tsx
+++ b/src/hooks/use-user-profile.tsx
@@ -75,7 +75,7 @@ export function useUserProfile() {
 
 export function usePermissions() {
   const { loading, profile } = useUserProfile();
-  const { selectedPlanId } = usePlans();
+  const { selectedPlanId, selectedPlan } = usePlans();
 
   const frameworkConfigPermissions = useMemo(() => {
     if (!loading && selectedPlanId) {
@@ -94,12 +94,15 @@ export function usePermissions() {
       )) ??
     false;
 
+  const isLocked = selectedPlan?.locked ?? false;
+
   return {
     isFrameworkAdmin:
       !!profile?.framework?.userRoles?.includes(FRAMEWORK_ADMIN_ROLE),
     isLoading: loading,
     create: canCreate,
-    edit: frameworkConfigPermissions?.change ?? false,
+    edit: (frameworkConfigPermissions?.change ?? false) && !isLocked,
     delete: frameworkConfigPermissions?.delete ?? false,
+    isLocked,
   };
 }

--- a/src/hooks/use-user-profile.tsx
+++ b/src/hooks/use-user-profile.tsx
@@ -95,14 +95,17 @@ export function usePermissions() {
     false;
 
   const isLocked = selectedPlan?.locked ?? false;
+  const isFrameworkAdmin = !!profile?.framework?.userRoles?.includes(FRAMEWORK_ADMIN_ROLE);
+  const canDelete = frameworkConfigPermissions?.delete ?? false;
 
   return {
-    isFrameworkAdmin:
-      !!profile?.framework?.userRoles?.includes(FRAMEWORK_ADMIN_ROLE),
+    isFrameworkAdmin,
+    // True for both framework-admin (all instances) and instance-admin (this instance)
+    isAdmin: isFrameworkAdmin || canDelete,
     isLoading: loading,
     create: canCreate,
     edit: (frameworkConfigPermissions?.change ?? false) && !isLocked,
-    delete: frameworkConfigPermissions?.delete ?? false,
+    delete: canDelete,
     isLocked,
   };
 }

--- a/src/hooks/use-user-profile.tsx
+++ b/src/hooks/use-user-profile.tsx
@@ -104,7 +104,7 @@ export function usePermissions() {
     isAdmin: isFrameworkAdmin || canDelete,
     isLoading: loading,
     create: canCreate,
-    edit: frameworkConfigPermissions?.change ?? false,
+    edit: profile?.framework?.userPermissions?.change ?? false,
     delete: canDelete,
     isLocked,
   };

--- a/src/hooks/use-user-profile.tsx
+++ b/src/hooks/use-user-profile.tsx
@@ -13,7 +13,7 @@ type UserProfileContextType = {
   profile: ProfileQuery | null;
 }
 
-const UserProfileContext = createContext<UserProfileContextType>({
+export const UserProfileContext = createContext<UserProfileContextType>({
   loading: false,
   profile: null,
 });

--- a/src/queries/framework/get-framework-config.ts
+++ b/src/queries/framework/get-framework-config.ts
@@ -11,8 +11,8 @@ export const GET_FRAMEWORK_CONFIG = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        # TODO: Add when backend support ready
-        # locked
+        instanceIdentifier
+        isLocked
       }
     }
   }
@@ -29,7 +29,8 @@ export const GET_FRAMEWORK_CONFIGS = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        # locked
+        instanceIdentifier
+        isLocked
       }
     }
   }

--- a/src/queries/framework/get-framework-config.ts
+++ b/src/queries/framework/get-framework-config.ts
@@ -11,6 +11,8 @@ export const GET_FRAMEWORK_CONFIG = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
+        # TODO: Add when backend support ready
+        # locked
       }
     }
   }
@@ -27,6 +29,7 @@ export const GET_FRAMEWORK_CONFIGS = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
+        # locked
       }
     }
   }

--- a/src/queries/framework/lock-framework-config.ts
+++ b/src/queries/framework/lock-framework-config.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client';
+
+export const LOCK_FRAMEWORK_CONFIG = gql`
+  mutation LockFrameworkConfig($id: ID!, $locked: Boolean!) {
+    updateFrameworkConfig(id: $id, locked: $locked) {
+      ok
+      frameworkConfig {
+        id
+        locked
+      }
+    }
+  }
+`;
+
+// TODO: Remove this when backend support ready
+export interface LockFrameworkConfigMutation {
+  updateFrameworkConfig: {
+    ok: boolean | null;
+    frameworkConfig: { id: string; locked: boolean } | null;
+  } | null;
+}
+
+export interface LockFrameworkConfigMutationVariables {
+  id: string;
+  locked: boolean;
+}

--- a/src/queries/framework/lock-framework-config.ts
+++ b/src/queries/framework/lock-framework-config.ts
@@ -1,26 +1,32 @@
-import { gql } from '@apollo/client';
+import { gql, useMutation } from '@apollo/client';
 
-export const LOCK_FRAMEWORK_CONFIG = gql`
-  mutation LockFrameworkConfig($id: ID!, $locked: Boolean!) {
-    updateFrameworkConfig(id: $id, locked: $locked) {
-      ok
-      frameworkConfig {
-        id
-        locked
-      }
+import type {
+  SetInstanceLockedMutation,
+  SetInstanceLockedMutationVariables,
+} from '@/types/__generated__/graphql';
+
+export const SET_INSTANCE_LOCKED = gql`
+  mutation SetInstanceLocked($instanceId: ID!, $isLocked: Boolean!) {
+    setInstanceLocked(instanceId: $instanceId, isLocked: $isLocked) {
+      __typename
     }
   }
 `;
 
-// TODO: Remove this when backend support ready
-export interface LockFrameworkConfigMutation {
-  updateFrameworkConfig: {
-    ok: boolean | null;
-    frameworkConfig: { id: string; locked: boolean } | null;
-  } | null;
-}
+export function useSetInstanceLocked(frameworkConfigId?: string) {
+  return useMutation<SetInstanceLockedMutation, SetInstanceLockedMutationVariables>(
+    SET_INSTANCE_LOCKED,
+    {
+      update(cache, _result, { variables }) {
+        if (!variables || !frameworkConfigId) return;
 
-export interface LockFrameworkConfigMutationVariables {
-  id: string;
-  locked: boolean;
+        cache.modify({
+          id: cache.identify({ __typename: 'FrameworkConfig', id: frameworkConfigId }),
+          fields: {
+            isLocked: () => variables.isLocked,
+          },
+        });
+      },
+    }
+  );
 }

--- a/src/types/__generated__/graphql.ts
+++ b/src/types/__generated__/graphql.ts
@@ -843,6 +843,8 @@ export type FrameworkConfig = {
   uuid: Scalars['UUID']['output'];
   /** Public URL for instance dashboard */
   viewUrl?: Maybe<Scalars['String']['output']>;
+  // Added manually — regenerate once backend supports this field
+  locked?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type FrameworkConfigInput = {
@@ -1466,6 +1468,8 @@ export type MutationSetParameterArgs = {
 export type MutationUpdateFrameworkConfigArgs = {
   baselineYear?: InputMaybe<Scalars['Int']['input']>;
   id: Scalars['ID']['input'];
+  // Added manually — regenerate once backend supports this field
+  locked?: InputMaybe<Scalars['Boolean']['input']>;
   organizationIdentifier?: InputMaybe<Scalars['String']['input']>;
   organizationName?: InputMaybe<Scalars['String']['input']>;
   organizationSlug?: InputMaybe<Scalars['String']['input']>;
@@ -2714,7 +2718,7 @@ export type GetFrameworkConfigQueryVariables = Exact<{
 export type GetFrameworkConfigQuery = (
   { framework?: (
     { id: string, config?: (
-      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, locked?: boolean | null }
       & { __typename?: 'FrameworkConfig' }
     ) | null }
     & { __typename?: 'Framework' }
@@ -2728,7 +2732,7 @@ export type GetFrameworkConfigsQueryVariables = Exact<{ [key: string]: never; }>
 export type GetFrameworkConfigsQuery = (
   { framework?: (
     { id: string, configs: Array<(
-      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, locked?: boolean | null }
       & { __typename?: 'FrameworkConfig' }
     )> }
     & { __typename?: 'Framework' }

--- a/src/types/__generated__/graphql.ts
+++ b/src/types/__generated__/graphql.ts
@@ -14,12 +14,29 @@ export type Scalars = {
   Float: { input: number; output: number; }
   Date: { input: any; output: any; }
   DateTime: { input: string; output: string; }
+  JSON: { input: any; output: any; }
   JSONString: { input: string; output: string; }
-  PointScalar: { input: any; output: any; }
   PositiveInt: { input: number; output: number; }
   RichText: { input: string; output: string; }
   UUID: { input: string; output: string; }
   _Any: { input: any; output: any; }
+};
+
+export type ActionConfigInput = {
+  decisionLevel?: InputMaybe<DecisionLevel>;
+  group?: InputMaybe<Scalars['String']['input']>;
+  noEffectValue?: InputMaybe<Scalars['Float']['input']>;
+  nodeClass: Scalars['String']['input'];
+  parent?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ActionConfigType = {
+  __typename?: 'ActionConfigType';
+  decisionLevel?: Maybe<DecisionLevel>;
+  group?: Maybe<Scalars['String']['output']>;
+  noEffectValue?: Maybe<Scalars['Float']['output']>;
+  nodeClass: Scalars['String']['output'];
+  parent?: Maybe<Scalars['String']['output']>;
 };
 
 export type ActionGroupType = {
@@ -35,7 +52,7 @@ export type ActionImpact = {
   action: ActionNode;
   costDim?: Maybe<DimensionalMetricType>;
   /** @deprecated Use costDim instead. */
-  costValues?: Maybe<Array<Maybe<YearlyValue>>>;
+  costValues?: Maybe<Array<YearlyValue>>;
   effectDim: DimensionalMetricType;
   /** @deprecated Use effectDim instead. */
   impactValues?: Maybe<Array<Maybe<YearlyValue>>>;
@@ -84,16 +101,19 @@ export type ActionListPage = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   owner?: Maybe<UserType>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
   showActionComparison?: Maybe<Scalars['Boolean']['output']>;
   showCumulativeImpact?: Maybe<Scalars['Boolean']['output']>;
+  showInAdditionalLinks: Scalars['Boolean']['output'];
   showInFooter: Scalars['Boolean']['output'];
   showInMenus: Scalars['Boolean']['output'];
   showOnlyMunicipalActions?: Maybe<Scalars['Boolean']['output']>;
@@ -106,28 +126,9 @@ export type ActionListPage = PageInterface & {
 };
 
 
-export type ActionListPageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type ActionListPageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type ActionListPageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -135,65 +136,66 @@ export type ActionListPageDescendantsArgs = {
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
-
-export type ActionListPageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type ActionNode = NodeInterface & {
+export type ActionNode = EditableEntity & NodeInterface & {
   __typename?: 'ActionNode';
   body?: Maybe<Array<StreamFieldInterface>>;
+  /** Row-level change history for this node, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
   color?: Maybe<Scalars['String']['output']>;
   decisionLevel?: Maybe<DecisionLevel>;
   description?: Maybe<Scalars['String']['output']>;
   dimensionalFlow?: Maybe<DimensionalFlowType>;
   downstreamNodes: Array<NodeInterface>;
+  editor?: Maybe<NodeEditor>;
   explanation?: Maybe<Scalars['String']['output']>;
   goal?: Maybe<Scalars['RichText']['output']>;
   goals: Array<NodeGoal>;
   group?: Maybe<ActionGroupType>;
   id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
   impactMetric?: Maybe<ForecastMetricType>;
   impactMetrics: Array<ForecastMetricType>;
   indicatorNode?: Maybe<Node>;
-  inputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   inputNodes: Array<NodeInterface>;
   /** @deprecated Use __typeName instead */
   isAction: Scalars['Boolean']['output'];
   isEnabled: Scalars['Boolean']['output'];
   isVisible: Scalars['Boolean']['output'];
+  kind?: Maybe<NodeKind>;
   metric?: Maybe<ForecastMetricType>;
   metricDim?: Maybe<DimensionalMetricType>;
   metrics?: Maybe<Array<ForecastMetricType>>;
   name: Scalars['String']['output'];
-  nodeType: Scalars['String']['output'];
   order?: Maybe<Scalars['Int']['output']>;
   outcome?: Maybe<DimensionalMetricType>;
-  outputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   outputNodes: Array<NodeInterface>;
   parameters: Array<ParameterInterface>;
   parentAction?: Maybe<ActionNode>;
   quantity?: Maybe<Scalars['String']['output']>;
+  quantityKind?: Maybe<QuantityKindType>;
+  /** Stable UUID, populated for DB-backed nodes. Null for unsynced YAML nodes. */
+  resolveUuid?: Maybe<Scalars['UUID']['output']>;
   shortDescription?: Maybe<Scalars['RichText']['output']>;
   shortName?: Maybe<Scalars['String']['output']>;
   subactions: Array<ActionNode>;
-  tags?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** @deprecated Replaced by "goals". */
   targetYearGoal?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
   upstreamNodes: Array<NodeInterface>;
+  uuid: Scalars['UUID']['output'];
   visualizations?: Maybe<Array<VisualizationEntry>>;
+};
+
+
+export type ActionNodeChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
 };
 
 
 export type ActionNodeDownstreamNodesArgs = {
   maxDepth?: InputMaybe<Scalars['Int']['input']>;
-  onlyOutcome?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyOutcome?: Scalars['Boolean']['input'];
   untilNode?: InputMaybe<Scalars['ID']['input']>;
 };
 
@@ -221,9 +223,9 @@ export type ActionNodeMetricDimArgs = {
 
 
 export type ActionNodeUpstreamNodesArgs = {
-  includeActions?: InputMaybe<Scalars['Boolean']['input']>;
-  sameQuantity?: InputMaybe<Scalars['Boolean']['input']>;
-  sameUnit?: InputMaybe<Scalars['Boolean']['input']>;
+  includeActions?: Scalars['Boolean']['input'];
+  sameQuantity?: Scalars['Boolean']['input'];
+  sameUnit?: Scalars['Boolean']['input'];
 };
 
 /** An enumeration. */
@@ -236,11 +238,15 @@ export enum ActionSortOrder {
   Standard = 'STANDARD'
 }
 
-export type ActivateScenarioMutation = {
-  __typename?: 'ActivateScenarioMutation';
-  activeScenario?: Maybe<ScenarioType>;
-  ok?: Maybe<Scalars['Boolean']['output']>;
+export type ActivateScenarioResult = {
+  __typename?: 'ActivateScenarioResult';
+  activeScenario: ScenarioType;
+  ok: Scalars['Boolean']['output'];
 };
+
+export type AddNodeInputPortPayload = InputPortType | OperationInfo;
+
+export type AddNodeOutputPortPayload = OperationInfo | OutputPortType;
 
 export type AdminButton = {
   __typename?: 'AdminButton';
@@ -250,6 +256,17 @@ export type AdminButton = {
   target?: Maybe<Scalars['String']['output']>;
   title?: Maybe<Scalars['String']['output']>;
   url: Scalars['String']['output'];
+};
+
+export type AssignCategoryTransformationInput = {
+  category: Scalars['String']['input'];
+  dimension: Scalars['String']['input'];
+};
+
+export type AssignCategoryTransformationType = {
+  __typename?: 'AssignCategoryTransformationType';
+  category: Scalars['String']['output'];
+  dimension: Scalars['String']['output'];
 };
 
 export type BlockQuoteBlock = StreamFieldInterface & {
@@ -270,9 +287,9 @@ export type BoolParameterType = ParameterInterface & {
   isCustomizable: Scalars['Boolean']['output'];
   isCustomized: Scalars['Boolean']['output'];
   label?: Maybe<Scalars['String']['output']>;
-  /** ID of parameter in the node's namespace */
   localId?: Maybe<Scalars['ID']['output']>;
   node?: Maybe<NodeInterface>;
+  /** ID of parameter in the node's namespace */
   nodeRelativeId?: Maybe<Scalars['ID']['output']>;
   value?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -326,6 +343,17 @@ export type CategoryBreakdownBlock = StreamFieldInterface & {
   title: Scalars['String']['output'];
 };
 
+export enum ChangeTargetKind {
+  DatasetPort = 'DATASET_PORT',
+  DataPoint = 'DATA_POINT',
+  Dimension = 'DIMENSION',
+  DimensionCategory = 'DIMENSION_CATEGORY',
+  Edge = 'EDGE',
+  Instance = 'INSTANCE',
+  Node = 'NODE',
+  Unknown = 'UNKNOWN'
+}
+
 export type CharBlock = StreamFieldInterface & {
   __typename?: 'CharBlock';
   blockType: Scalars['String']['output'];
@@ -368,11 +396,57 @@ export type CoverageOutput = {
   xml?: Maybe<Scalars['String']['output']>;
 };
 
+export type CreateDataPointInput = {
+  date: Scalars['Date']['input'];
+  dimensionCategoryIds?: InputMaybe<Array<Scalars['UUID']['input']>>;
+  metricId: Scalars['UUID']['input'];
+  value?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type CreateDataPointPayload = DataPoint | OperationInfo;
+
+export type CreateDimensionCategoriesPayload = InstanceDimension | OperationInfo;
+
+export type CreateDimensionCategoryInput = {
+  dimensionId: Scalars['UUID']['input'];
+  id?: InputMaybe<Scalars['UUID']['input']>;
+  identifier?: InputMaybe<Scalars['String']['input']>;
+  label: Scalars['String']['input'];
+  nextSibling?: InputMaybe<Scalars['ID']['input']>;
+  previousSibling?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type CreateEdgeInput = {
+  fromNodeId: Scalars['String']['input'];
+  fromPort?: Scalars['String']['input'];
+  instanceId: Scalars['ID']['input'];
+  toNodeId: Scalars['String']['input'];
+  toPort?: InputMaybe<Scalars['String']['input']>;
+  transformations?: InputMaybe<Array<EdgeTransformationInput>>;
+};
+
+export type CreateEdgePayload = NodeEdgeType | OperationInfo;
+
 export type CreateFrameworkConfigMutation = {
   __typename?: 'CreateFrameworkConfigMutation';
   /** The created framework config instance */
   frameworkConfig?: Maybe<FrameworkConfig>;
   ok: Scalars['Boolean']['output'];
+};
+
+export type CreateInstanceInput = {
+  frameworkId: Scalars['String']['input'];
+  identifier: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  organizationName: Scalars['String']['input'];
+};
+
+export type CreateInstancePayload = CreateInstanceResult | OperationInfo;
+
+export type CreateInstanceResult = {
+  __typename?: 'CreateInstanceResult';
+  instanceId: Scalars['ID']['output'];
+  instanceName: Scalars['String']['output'];
 };
 
 export type CreateNzcFrameworkConfigMutation = {
@@ -382,26 +456,41 @@ export type CreateNzcFrameworkConfigMutation = {
   ok: Scalars['Boolean']['output'];
 };
 
-export type CreateOrganizationMutationInput = {
-  /** A simplified short version of name for the general public */
-  abbreviation?: InputMaybe<Scalars['String']['input']>;
-  classification?: InputMaybe<Scalars['ID']['input']>;
-  clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** A date of dissolution */
-  dissolutionDate?: InputMaybe<Scalars['Date']['input']>;
-  /** A date of founding */
-  foundingDate?: InputMaybe<Scalars['Date']['input']>;
-  /** A primary name, e.g. a legally recognized name */
-  name: Scalars['String']['input'];
-  parent?: InputMaybe<Scalars['ID']['input']>;
+export type CreateNodeInput = {
+  allowNulls?: Scalars['Boolean']['input'];
+  color?: InputMaybe<Scalars['String']['input']>;
+  config: NodeConfigInput;
+  description?: InputMaybe<Scalars['String']['input']>;
+  i18n?: InputMaybe<Scalars['JSON']['input']>;
+  identifier: Scalars['ID']['input'];
+  inputDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  inputPorts?: InputMaybe<Array<InputPortInput>>;
+  isOutcome?: Scalars['Boolean']['input'];
+  isVisible?: Scalars['Boolean']['input'];
+  kind?: NodeKind;
+  minimumYear?: InputMaybe<Scalars['Int']['input']>;
+  name?: Scalars['String']['input'];
+  nodeGroup?: InputMaybe<Scalars['ID']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  outputDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  outputMetrics?: InputMaybe<Array<OutputMetricInput>>;
+  outputPorts?: InputMaybe<Array<OutputPortInput>>;
+  params?: InputMaybe<Scalars['JSON']['input']>;
+  shortName?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
-export type CreateOrganizationMutationPayload = {
-  __typename?: 'CreateOrganizationMutationPayload';
-  clientMutationId?: Maybe<Scalars['String']['output']>;
-  errors: Array<ErrorType>;
-  organization?: Maybe<Organization>;
+export type CreateNodePayload = ActionNode | Node | OperationInfo;
+
+export type CreateScenarioInput = {
+  allActionsEnabled?: Scalars['Boolean']['input'];
+  identifier: Scalars['String']['input'];
+  instanceId: Scalars['ID']['input'];
+  kind?: Scalars['String']['input'];
+  name: Scalars['String']['input'];
 };
+
+export type CreateScenarioPayload = OperationInfo | ScenarioType;
 
 export type CurrentProgressBarBlock = StreamFieldInterface & {
   __typename?: 'CurrentProgressBarBlock';
@@ -465,14 +554,17 @@ export type DashboardPage = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   owner?: Maybe<UserType>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
+  showInAdditionalLinks: Scalars['Boolean']['output'];
   showInFooter: Scalars['Boolean']['output'];
   showInMenus: Scalars['Boolean']['output'];
   siblings: Array<PageInterface>;
@@ -484,28 +576,9 @@ export type DashboardPage = PageInterface & {
 };
 
 
-export type DashboardPageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type DashboardPageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type DashboardPageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -513,14 +586,133 @@ export type DashboardPageDescendantsArgs = {
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type DataPoint = {
+  __typename?: 'DataPoint';
+  date: Scalars['Date']['output'];
+  dimensionCategories: Array<DatasetDimensionCategory>;
+  id: Scalars['ID']['output'];
+  metric: DatasetMetric;
+  value?: Maybe<Scalars['Float']['output']>;
+};
 
-export type DashboardPageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
+export type Dataset = {
+  __typename?: 'Dataset';
+  data: Array<DimensionalMetricType>;
+  dataPoints: Array<DataPoint>;
+  dimensions: Array<DatasetDimension>;
+  /** External source reference for externally backed datasets. */
+  externalRef?: Maybe<DatasetExternalRefType>;
+  id: Scalars['ID']['output'];
+  identifier?: Maybe<Scalars['String']['output']>;
+  /** Whether the dataset object is only a placeholder without imported datapoints. */
+  isExternalPlaceholder: Scalars['Boolean']['output'];
+  metrics: Array<DatasetMetric>;
+  name: Scalars['String']['output'];
+  portBindings: Array<DatasetPortType>;
+};
+
+export type DatasetDimension = {
+  __typename?: 'DatasetDimension';
+  categories: Array<DatasetDimensionCategory>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type DatasetDimensionCategory = {
+  __typename?: 'DatasetDimensionCategory';
+  identifier?: Maybe<Scalars['String']['output']>;
+  label: Scalars['String']['output'];
+  uuid: Scalars['UUID']['output'];
+};
+
+export type DatasetEditorMutation = {
+  __typename?: 'DatasetEditorMutation';
+  /** Create a data point */
+  createDataPoint: CreateDataPointPayload;
+  /** Delete a data point */
+  deleteDataPoint?: Maybe<OperationInfo>;
+  /** Update a data point */
+  updateDataPoint: UpdateDataPointPayload;
+};
+
+
+export type DatasetEditorMutationCreateDataPointArgs = {
+  input: CreateDataPointInput;
+};
+
+
+export type DatasetEditorMutationDeleteDataPointArgs = {
+  dataPointId: Scalars['ID']['input'];
+};
+
+
+export type DatasetEditorMutationUpdateDataPointArgs = {
+  dataPointId: Scalars['ID']['input'];
+  input: UpdateDataPointInput;
+};
+
+export type DatasetExternalRefType = {
+  __typename?: 'DatasetExternalRefType';
+  /** Repository commit used for this dataset snapshot. */
+  commit?: Maybe<Scalars['String']['output']>;
+  /** Path-like identifier of the dataset inside the external repository. */
+  datasetId: Scalars['String']['output'];
+  /** URL of the external dataset repository. */
+  repoUrl: Scalars['String']['output'];
+};
+
+export type DatasetMetric = {
+  __typename?: 'DatasetMetric';
+  id: Scalars['ID']['output'];
+  /** Human-readable label. */
+  label: Scalars['String']['output'];
+  /** Column name used in DataFrames. */
+  name?: Maybe<Scalars['String']['output']>;
+  nextSibling?: Maybe<Scalars['ID']['output']>;
+  previousSibling?: Maybe<Scalars['ID']['output']>;
+  unit: Scalars['String']['output'];
+};
+
+export type DatasetMetricRefType = {
+  __typename?: 'DatasetMetricRefType';
+  /** Globally unique identifier of the dataset metric object. */
+  id: Scalars['ID']['output'];
+  /** Human-readable label of the metric. */
+  label: Scalars['String']['output'];
+  /** Stable identifier of the metric within its dataset schema. */
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type DatasetPortType = EditableEntity & {
+  __typename?: 'DatasetPortType';
+  /** Row-level change history for this dataset-port binding, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
+  data: Array<DimensionalMetricType>;
+  dataset?: Maybe<Dataset>;
+  /** Stable identifier of the external dataset, typically the dataset repo path without extension. */
+  externalDatasetId?: Maybe<Scalars['String']['output']>;
+  /** Stable identifier of the external metric within the dataset. */
+  externalMetricId?: Maybe<Scalars['String']['output']>;
+  /** Globally unique identifier of the dataset-port binding. */
+  id: Scalars['ID']['output'];
+  /** Dataset metric object bound to this port. */
+  metric?: Maybe<DatasetMetricRefType>;
+  /** Reference to the node and its bound input port. */
+  nodeRef: NodePortRef;
+  uuid: Scalars['UUID']['output'];
+};
+
+
+export type DatasetPortTypeChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
+};
+
+export type DatasetRepoType = {
+  __typename?: 'DatasetRepoType';
+  commit?: Maybe<Scalars['String']['output']>;
+  dvcRemote?: Maybe<Scalars['String']['output']>;
+  url: Scalars['String']['output'];
 };
 
 export type DateBlock = StreamFieldInterface & {
@@ -560,7 +752,7 @@ export type DecimalBlock = StreamFieldInterface & {
   value: Scalars['Float']['output'];
 };
 
-/** An enumeration. */
+/** Which governance level is applicable for an action */
 export enum DecisionLevel {
   Eu = 'EU',
   Municipality = 'MUNICIPALITY',
@@ -569,11 +761,6 @@ export enum DecisionLevel {
 
 export type DeleteFrameworkConfigMutation = {
   __typename?: 'DeleteFrameworkConfigMutation';
-  ok?: Maybe<Scalars['Boolean']['output']>;
-};
-
-export type DeleteOrganizationMutation = {
-  __typename?: 'DeleteOrganizationMutation';
   ok?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -647,6 +834,26 @@ export type DocumentObjectType = {
   url: Scalars['String']['output'];
 };
 
+export type EdgeTransformationInput = {
+  assignCategory?: InputMaybe<AssignCategoryTransformationInput>;
+  flatten?: InputMaybe<FlattenTransformationInput>;
+  selectCategories?: InputMaybe<SelectCategoriesTransformationInput>;
+};
+
+export type EdgeTransformationUnion = AssignCategoryTransformationType | FlattenTransformationType | SelectCategoriesTransformationType;
+
+export type EditableEntity = {
+  /** Row-level change history for this entity, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
+  uuid: Scalars['UUID']['output'];
+};
+
+
+export type EditableEntityChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
+};
+
 export type EmailBlock = StreamFieldInterface & {
   __typename?: 'EmailBlock';
   blockType: Scalars['String']['output'];
@@ -668,10 +875,13 @@ export type EmbedBlock = StreamFieldInterface & {
   value: Scalars['String']['output'];
 };
 
-export type ErrorType = {
-  __typename?: 'ErrorType';
-  field: Scalars['String']['output'];
-  messages: Array<Scalars['String']['output']>;
+export type FlattenTransformationInput = {
+  dimension: Scalars['String']['input'];
+};
+
+export type FlattenTransformationType = {
+  __typename?: 'FlattenTransformationType';
+  dimension: Scalars['String']['output'];
 };
 
 export type FloatBlock = StreamFieldInterface & {
@@ -708,8 +918,6 @@ export type ForecastMetricType = {
   historicalValues: Array<YearlyValue>;
   id?: Maybe<Scalars['ID']['output']>;
   name?: Maybe<Scalars['String']['output']>;
-  /** Will be set if the node outputs multiple time-series */
-  outputNode?: Maybe<Node>;
   unit?: Maybe<UnitType>;
   yearlyCumulativeUnit?: Maybe<UnitType>;
 };
@@ -717,6 +925,15 @@ export type ForecastMetricType = {
 
 export type ForecastMetricTypeHistoricalValuesArgs = {
   latest?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type FormulaConfigInput = {
+  formula: Scalars['String']['input'];
+};
+
+export type FormulaConfigType = {
+  __typename?: 'FormulaConfigType';
+  formula: Scalars['String']['output'];
 };
 
 /**
@@ -738,6 +955,10 @@ export type ForecastMetricTypeHistoricalValuesArgs = {
  */
 export type Framework = {
   __typename?: 'Framework';
+  /** Whether authenticated users can create new model instances under this framework. */
+  allowInstanceCreation: Scalars['Boolean']['output'];
+  /** Whether new users can self-register under this framework. */
+  allowUserRegistration: Scalars['Boolean']['output'];
   config?: Maybe<FrameworkConfig>;
   configs: Array<FrameworkConfig>;
   defaults: FrameworkDefaultsType;
@@ -831,6 +1052,8 @@ export type FrameworkConfig = {
   framework: Framework;
   id: Scalars['ID']['output'];
   instance?: Maybe<InstanceType>;
+  instanceIdentifier: Scalars['String']['output'];
+  isLocked: Scalars['Boolean']['output'];
   measures: Array<Measure>;
   organizationIdentifier?: Maybe<Scalars['String']['output']>;
   organizationName?: Maybe<Scalars['String']['output']>;
@@ -843,8 +1066,6 @@ export type FrameworkConfig = {
   uuid: Scalars['UUID']['output'];
   /** Public URL for instance dashboard */
   viewUrl?: Maybe<Scalars['String']['output']>;
-  // Added manually — regenerate once backend supports this field
-  locked?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type FrameworkConfigInput = {
@@ -868,6 +1089,20 @@ export type FrameworkDefaultsType = {
   targetYear: MinMaxDefaultIntType;
 };
 
+export type FrameworkLandingBlock = StreamFieldInterface & {
+  __typename?: 'FrameworkLandingBlock';
+  blockType: Scalars['String']['output'];
+  blocks: Array<StreamFieldInterface>;
+  body?: Maybe<Scalars['String']['output']>;
+  ctaLabel?: Maybe<Scalars['String']['output']>;
+  ctaUrl?: Maybe<Scalars['String']['output']>;
+  field: Scalars['String']['output'];
+  framework?: Maybe<Framework>;
+  heading: Scalars['String']['output'];
+  id?: Maybe<Scalars['String']['output']>;
+  rawValue: Scalars['String']['output'];
+};
+
 /** An enumeration. */
 export enum FrameworksMeasureTemplatePriorityChoices {
   /** High */
@@ -889,6 +1124,25 @@ export type GoalProgressBarBlock = StreamFieldInterface & {
   id?: Maybe<Scalars['String']['output']>;
   rawValue: Scalars['String']['output'];
   title: Scalars['String']['output'];
+};
+
+export type GraphLayout = {
+  __typename?: 'GraphLayout';
+  actionIds: Array<Scalars['ID']['output']>;
+  coreNodeIds: Array<Scalars['ID']['output']>;
+  ghostableContextSourceIds: Array<Scalars['ID']['output']>;
+  hubIds: Array<Scalars['ID']['output']>;
+  mainGraphNodeIds: Array<Scalars['ID']['output']>;
+  outcomeIds: Array<Scalars['ID']['output']>;
+  thresholds: GraphLayoutThresholds;
+};
+
+export type GraphLayoutThresholds = {
+  __typename?: 'GraphLayoutThresholds';
+  ghostableAvgOutgoingSpan: Scalars['Float']['output'];
+  ghostableOutDegree: Scalars['Int']['output'];
+  ghostableTotalDegree: Scalars['Int']['output'];
+  hubDegree: Scalars['Int']['output'];
 };
 
 export type ImageBlock = StreamFieldInterface & {
@@ -995,7 +1249,33 @@ export type ImpactOverviewType = {
   indicatorLabel?: Maybe<Scalars['String']['output']>;
   indicatorUnit: UnitType;
   label: Scalars['String']['output'];
+  outcomeDimension?: Maybe<Scalars['String']['output']>;
   plotLimitForIndicator?: Maybe<Scalars['Float']['output']>;
+  stakeholderDimension?: Maybe<Scalars['String']['output']>;
+};
+
+export type InputPortBindingUnion = DatasetPortType | NodeEdgeType;
+
+export type InputPortInput = {
+  id?: InputMaybe<Scalars['UUID']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  multi?: Scalars['Boolean']['input'];
+  quantity?: InputMaybe<Scalars['String']['input']>;
+  requiredDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  supportedDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  unit?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type InputPortType = {
+  __typename?: 'InputPortType';
+  bindings: Array<InputPortBindingUnion>;
+  id: Scalars['UUID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  multi: Scalars['Boolean']['output'];
+  quantity?: Maybe<Scalars['String']['output']>;
+  requiredDimensions: Array<Scalars['String']['output']>;
+  supportedDimensions: Array<Scalars['String']['output']>;
+  unit?: Maybe<UnitType>;
 };
 
 export type InstanceBasicConfiguration = {
@@ -1016,22 +1296,226 @@ export type InstanceChange = {
   modifiedAt: Scalars['DateTime']['output'];
 };
 
+export type InstanceChangeOperationType = {
+  __typename?: 'InstanceChangeOperationType';
+  /** Top-level action that triggered the operation, e.g. 'node.delete'. */
+  action: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  /** Row-level entries bundled under this operation, in insertion order. */
+  entries: Array<InstanceModelLogEntryType>;
+  /** Transport that initiated the operation (graphql / rest / admin / cli / migration). */
+  source: Scalars['String']['output'];
+  /** UUID of the operation that undid this one, if any. */
+  supersededByUuid?: Maybe<Scalars['UUID']['output']>;
+  /** Email of the user who initiated the operation, or null for system. */
+  userEmail?: Maybe<Scalars['String']['output']>;
+  uuid: Scalars['UUID']['output'];
+};
+
 export type InstanceContext = {
   hostname?: InputMaybe<Scalars['String']['input']>;
   identifier?: InputMaybe<Scalars['ID']['input']>;
   locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<PreviewMode>;
+  version?: InputMaybe<Scalars['UUID']['input']>;
 };
 
+export type InstanceDimension = {
+  __typename?: 'InstanceDimension';
+  categories: Array<InstanceDimensionCategory>;
+  id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type InstanceDimensionCategory = {
+  __typename?: 'InstanceDimensionCategory';
+  id: Scalars['ID']['output'];
+  identifier?: Maybe<Scalars['String']['output']>;
+  label: Scalars['String']['output'];
+  nextSibling?: Maybe<Scalars['ID']['output']>;
+  order: Scalars['Int']['output'];
+  previousSibling?: Maybe<Scalars['ID']['output']>;
+};
+
+export type InstanceEditor = {
+  __typename?: 'InstanceEditor';
+  /** Audit trail of user-facing edits to this instance, newest first. Each operation bundles one or more row-level entries. */
+  changeHistory: Array<InstanceChangeOperationType>;
+  configSource: Scalars['String']['output'];
+  datasetPorts: Array<DatasetPortType>;
+  datasets: Array<Dataset>;
+  dimensions: Array<InstanceDimension>;
+  /** Optimistic-locking token for draft edits. Editing mutations must pass this value via `@instance(version: ...)` or `@context(input: { version: ... })`; mismatched tokens are rejected with a stale-version error. `null` if no edits have ever been recorded for this instance. */
+  draftHeadToken?: Maybe<Scalars['UUID']['output']>;
+  edges: Array<NodeEdgeType>;
+  firstPublishedAt?: Maybe<Scalars['DateTime']['output']>;
+  graphLayout: GraphLayout;
+  hasUnpublishedChanges: Scalars['Boolean']['output'];
+  isLocked: Scalars['Boolean']['output'];
+  lastPublishedAt?: Maybe<Scalars['DateTime']['output']>;
+  live: Scalars['Boolean']['output'];
+  spec?: Maybe<InstanceSpec>;
+};
+
+
+export type InstanceEditorChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
+};
+
+export type InstanceEditorMutation = {
+  __typename?: 'InstanceEditorMutation';
+  /** Append a new input port to a node */
+  addNodeInputPort: AddNodeInputPortPayload;
+  /** Append a new output port to a node */
+  addNodeOutputPort: AddNodeOutputPortPayload;
+  /** Add categories to a dimension */
+  createDimensionCategories: CreateDimensionCategoriesPayload;
+  /** Create a new edge between nodes */
+  createEdge: CreateEdgePayload;
+  /** Create a new node in the model */
+  createNode: CreateNodePayload;
+  /** Create a new scenario */
+  createScenario: CreateScenarioPayload;
+  /** Edit a DB-backed dataset that belongs to this instance */
+  datasetEditor: DatasetEditorMutation;
+  /** Delete a dimension category */
+  deleteDimensionCategory?: Maybe<OperationInfo>;
+  /** Delete an edge */
+  deleteEdge?: Maybe<OperationInfo>;
+  /** Delete a node and its edges */
+  deleteNode?: Maybe<OperationInfo>;
+  /** Delete a scenario */
+  deleteScenario?: Maybe<OperationInfo>;
+  /** Publish the current model state as a new revision */
+  publishModelInstance: PublishModelInstancePayload;
+  /** Revert draft to the last published revision */
+  revertModelInstance: InstanceType;
+  /** Update a dimension (e.g. rename) */
+  updateDimension: UpdateDimensionPayload;
+  /** Update dimension categories */
+  updateDimensionCategories: UpdateDimensionCategoriesPayload;
+  /** Update an existing node */
+  updateNode: UpdateNodePayload;
+  /** Update a scenario */
+  updateScenario: UpdateScenarioPayload;
+};
+
+
+export type InstanceEditorMutationAddNodeInputPortArgs = {
+  input: InputPortInput;
+  nodeId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationAddNodeOutputPortArgs = {
+  input: OutputPortInput;
+  nodeId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationCreateDimensionCategoriesArgs = {
+  input: Array<CreateDimensionCategoryInput>;
+};
+
+
+export type InstanceEditorMutationCreateEdgeArgs = {
+  input: CreateEdgeInput;
+};
+
+
+export type InstanceEditorMutationCreateNodeArgs = {
+  input: CreateNodeInput;
+};
+
+
+export type InstanceEditorMutationCreateScenarioArgs = {
+  input: CreateScenarioInput;
+};
+
+
+export type InstanceEditorMutationDatasetEditorArgs = {
+  datasetId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationDeleteDimensionCategoryArgs = {
+  categoryId: Scalars['UUID']['input'];
+};
+
+
+export type InstanceEditorMutationDeleteEdgeArgs = {
+  edgeId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationDeleteNodeArgs = {
+  nodeId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationDeleteScenarioArgs = {
+  scenarioId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationPublishModelInstanceArgs = {
+  instanceId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationRevertModelInstanceArgs = {
+  instanceId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationUpdateDimensionArgs = {
+  input: UpdateDimensionInput;
+};
+
+
+export type InstanceEditorMutationUpdateDimensionCategoriesArgs = {
+  input: Array<UpdateDimensionCategoryInput>;
+};
+
+
+export type InstanceEditorMutationUpdateNodeArgs = {
+  input: UpdateNodeInput;
+  nodeId: Scalars['ID']['input'];
+};
+
+
+export type InstanceEditorMutationUpdateScenarioArgs = {
+  input: UpdateScenarioInput;
+};
+
+/**
+ * Features available for the instance.
+ *
+ * Used mostly by the UI to customize the display of the results.
+ */
 export type InstanceFeaturesType = {
   __typename?: 'InstanceFeaturesType';
+  /** Whether to display the baseline data in graphs and visualizations. */
   baselineVisibleInGraphs: Scalars['Boolean']['output'];
+  /** Whether to hide detailed node information in the UI. */
   hideNodeDetails: Scalars['Boolean']['output'];
+  /** Maximum number of decimal places to display after the decimal point. None means no limit. */
   maximumFractionDigits?: Maybe<Scalars['Int']['output']>;
+  /** Whether authentication is required to access this instance. */
   requiresAuthentication: Scalars['Boolean']['output'];
+  /** Whether to display accumulated effects over time in the UI. */
   showAccumulatedEffects: Scalars['Boolean']['output'];
+  /** Whether to show category warnings in the node explanation. */
+  showCategoryWarnings: Scalars['Boolean']['output'];
+  /** Whether to show node explanation in the slot for description (under the graph). */
   showExplanations: Scalars['Boolean']['output'];
+  /** Whether to show a prompt to refresh data when it might be outdated. */
   showRefreshPrompt: Scalars['Boolean']['output'];
+  /** Number of significant digits to display in numerical results. None means no limit. */
   showSignificantDigits?: Maybe<Scalars['Int']['output']>;
+  /** Whether to use datasets from the database instead of the .parquet files. */
   useDatasetsFromDb: Scalars['Boolean']['output'];
 };
 
@@ -1059,14 +1543,33 @@ export type InstanceGoalEntry = {
 
 export type InstanceHostname = {
   __typename?: 'InstanceHostname';
-  basePath?: Maybe<Scalars['String']['output']>;
-  hostname?: Maybe<Scalars['String']['output']>;
+  basePath: Scalars['String']['output'];
+  hostname: Scalars['String']['output'];
+};
+
+export type InstanceModelLogEntryType = {
+  __typename?: 'InstanceModelLogEntryType';
+  /** Dotted action id, e.g. 'node.update'. */
+  action: Scalars['String']['output'];
+  /** State after the change. Null for delete operations. */
+  after?: Maybe<Scalars['JSON']['output']>;
+  /** State prior to the change. Null for create operations. */
+  before?: Maybe<Scalars['JSON']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  /** The affected entity if it still exists, null if deleted. */
+  target?: Maybe<EditableEntity>;
+  /** Discriminator for the affected entity. */
+  targetKind: ChangeTargetKind;
+  /** UUID of the affected entity. Survives deletion of the entity. */
+  targetUuid?: Maybe<Scalars['UUID']['output']>;
+  uuid: Scalars['UUID']['output'];
 };
 
 export type InstanceRootPage = PageInterface & {
   __typename?: 'InstanceRootPage';
   aliasOf?: Maybe<Page>;
   ancestors: Array<PageInterface>;
+  body?: Maybe<Array<Maybe<StreamFieldInterface>>>;
   children: Array<PageInterface>;
   contentType: Scalars['String']['output'];
   depth?: Maybe<Scalars['Int']['output']>;
@@ -1084,14 +1587,17 @@ export type InstanceRootPage = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   owner?: Maybe<UserType>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
+  showInAdditionalLinks: Scalars['Boolean']['output'];
   showInFooter: Scalars['Boolean']['output'];
   showInMenus: Scalars['Boolean']['output'];
   siblings: Array<PageInterface>;
@@ -1103,38 +1609,9 @@ export type InstanceRootPage = PageInterface & {
 };
 
 
-export type InstanceRootPageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type InstanceRootPageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type InstanceRootPageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type InstanceRootPageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -1150,28 +1627,41 @@ export type InstanceSiteContent = SnippetInterface & {
   snippetType: Scalars['String']['output'];
 };
 
+export type InstanceSpec = {
+  __typename?: 'InstanceSpec';
+  configSource: Scalars['String']['output'];
+  datasetRepo?: Maybe<DatasetRepoType>;
+  years: YearsDefType;
+};
+
 export type InstanceType = {
   __typename?: 'InstanceType';
   actionGroups: Array<ActionGroupType>;
   actionListPage?: Maybe<ActionListPage>;
   basePath: Scalars['String']['output'];
   defaultLanguage: Scalars['String']['output'];
+  editor?: Maybe<InstanceEditor>;
   features: InstanceFeaturesType;
   goals: Array<InstanceGoalEntry>;
   hostname?: Maybe<InstanceHostname>;
   id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
   introContent?: Maybe<Array<StreamFieldInterface>>;
+  isLocked: Scalars['Boolean']['output'];
   leadParagraph?: Maybe<Scalars['String']['output']>;
-  leadTitle?: Maybe<Scalars['String']['output']>;
+  leadTitle: Scalars['String']['output'];
   maximumHistoricalYear?: Maybe<Scalars['Int']['output']>;
   minimumHistoricalYear: Scalars['Int']['output'];
   modelEndYear: Scalars['Int']['output'];
   name: Scalars['String']['output'];
+  nodes: Array<NodeInterface>;
   owner?: Maybe<Scalars['String']['output']>;
   referenceYear?: Maybe<Scalars['Int']['output']>;
   supportedLanguages: Array<Scalars['String']['output']>;
   targetYear?: Maybe<Scalars['Int']['output']>;
   themeIdentifier?: Maybe<Scalars['String']['output']>;
+  uuid: Scalars['UUID']['output'];
+  years: YearsDefType;
 };
 
 
@@ -1182,6 +1672,11 @@ export type InstanceTypeGoalsArgs = {
 
 export type InstanceTypeHostnameArgs = {
   hostname: Scalars['String']['input'];
+};
+
+
+export type InstanceTypeNodesArgs = {
+  id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
 export type InstanceYearlyGoalType = {
@@ -1395,19 +1890,25 @@ export enum ModelAction {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  activateScenario?: Maybe<ActivateScenarioMutation>;
+  activateScenario: ActivateScenarioResult;
   createFrameworkConfig?: Maybe<CreateFrameworkConfigMutation>;
+  /** Create a new model instance under a framework, cloning from the framework template */
+  createInstance: CreateInstancePayload;
   createNzcFrameworkConfig?: Maybe<CreateNzcFrameworkConfigMutation>;
-  createOrganization?: Maybe<CreateOrganizationMutationPayload>;
   deleteFrameworkConfig?: Maybe<DeleteFrameworkConfigMutation>;
-  deleteOrganization?: Maybe<DeleteOrganizationMutation>;
-  resetParameter?: Maybe<ResetParameterMutation>;
+  /** Edit the nodes and edges of an instance */
+  instanceEditor: InstanceEditorMutation;
+  /** Register a new user with email and password */
+  registerUser: RegisterUserPayload;
+  resetParameter: ResetParameterResult;
+  /** Set whether an instance is locked for end-user mutations */
+  setInstanceLocked: SetInstanceLockedPayload;
   setNormalizer: SetNormalizerMutation;
-  setParameter?: Maybe<SetParameterMutation>;
+  /** Set the value of a parameter. Customized parameters are saved in a session. */
+  setParameter: SetParameterResult;
   updateFrameworkConfig?: Maybe<UpdateFrameworkConfigMutation>;
   updateMeasureDataPoint?: Maybe<UpdateMeasureDataPoint>;
   updateMeasureDataPoints?: Maybe<UpdateMeasureDataPoints>;
-  updateOrganization?: Maybe<UpdateOrganizationMutationPayload>;
 };
 
 
@@ -1426,14 +1927,14 @@ export type MutationCreateFrameworkConfigArgs = {
 };
 
 
-export type MutationCreateNzcFrameworkConfigArgs = {
-  configInput: FrameworkConfigInput;
-  nzcData: NzcCityEssentialData;
+export type MutationCreateInstanceArgs = {
+  input: CreateInstanceInput;
 };
 
 
-export type MutationCreateOrganizationArgs = {
-  input: CreateOrganizationMutationInput;
+export type MutationCreateNzcFrameworkConfigArgs = {
+  configInput: FrameworkConfigInput;
+  nzcData: NzcCityEssentialData;
 };
 
 
@@ -1442,13 +1943,25 @@ export type MutationDeleteFrameworkConfigArgs = {
 };
 
 
-export type MutationDeleteOrganizationArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
+export type MutationInstanceEditorArgs = {
+  instanceId: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['UUID']['input']>;
+};
+
+
+export type MutationRegisterUserArgs = {
+  input: RegisterUserInput;
 };
 
 
 export type MutationResetParameterArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type MutationSetInstanceLockedArgs = {
+  instanceId: Scalars['ID']['input'];
+  isLocked: Scalars['Boolean']['input'];
 };
 
 
@@ -1468,8 +1981,6 @@ export type MutationSetParameterArgs = {
 export type MutationUpdateFrameworkConfigArgs = {
   baselineYear?: InputMaybe<Scalars['Int']['input']>;
   id: Scalars['ID']['input'];
-  // Added manually — regenerate once backend supports this field
-  locked?: InputMaybe<Scalars['Boolean']['input']>;
   organizationIdentifier?: InputMaybe<Scalars['String']['input']>;
   organizationName?: InputMaybe<Scalars['String']['input']>;
   organizationSlug?: InputMaybe<Scalars['String']['input']>;
@@ -1491,11 +2002,6 @@ export type MutationUpdateMeasureDataPointsArgs = {
   measures: Array<MeasureInput>;
 };
 
-
-export type MutationUpdateOrganizationArgs = {
-  input: UpdateOrganizationMutationInput;
-};
-
 export type NzcCityEssentialData = {
   /** Population of the city */
   population: Scalars['Int']['input'];
@@ -1505,49 +2011,61 @@ export type NzcCityEssentialData = {
   temperature: LowHigh;
 };
 
-export type Node = NodeInterface & {
+export type Node = EditableEntity & NodeInterface & {
   __typename?: 'Node';
   body?: Maybe<Array<StreamFieldInterface>>;
+  /** Row-level change history for this node, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
   color?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   dimensionalFlow?: Maybe<DimensionalFlowType>;
   downstreamNodes: Array<NodeInterface>;
+  editor?: Maybe<NodeEditor>;
   explanation?: Maybe<Scalars['String']['output']>;
   goals: Array<NodeGoal>;
   id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
   impactMetric?: Maybe<ForecastMetricType>;
   impactMetrics: Array<ForecastMetricType>;
-  inputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   inputNodes: Array<NodeInterface>;
   /** @deprecated Use __typeName instead */
   isAction: Scalars['Boolean']['output'];
+  isOutcome: Scalars['Boolean']['output'];
   isVisible: Scalars['Boolean']['output'];
+  kind?: Maybe<NodeKind>;
   metric?: Maybe<ForecastMetricType>;
   metricDim?: Maybe<DimensionalMetricType>;
   metrics?: Maybe<Array<ForecastMetricType>>;
   name: Scalars['String']['output'];
-  nodeType: Scalars['String']['output'];
   order?: Maybe<Scalars['Int']['output']>;
   outcome?: Maybe<DimensionalMetricType>;
-  outputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   outputNodes: Array<NodeInterface>;
   parameters: Array<ParameterInterface>;
   quantity?: Maybe<Scalars['String']['output']>;
+  quantityKind?: Maybe<QuantityKindType>;
+  /** Stable UUID, populated for DB-backed nodes. Null for unsynced YAML nodes. */
+  resolveUuid?: Maybe<Scalars['UUID']['output']>;
   shortDescription?: Maybe<Scalars['RichText']['output']>;
   shortName?: Maybe<Scalars['String']['output']>;
-  tags?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** @deprecated Replaced by "goals". */
   targetYearGoal?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
-  upstreamActions?: Maybe<Array<ActionNode>>;
+  upstreamActions: Array<ActionNode>;
   upstreamNodes: Array<NodeInterface>;
+  uuid: Scalars['UUID']['output'];
   visualizations?: Maybe<Array<VisualizationEntry>>;
+};
+
+
+export type NodeChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
 };
 
 
 export type NodeDownstreamNodesArgs = {
   maxDepth?: InputMaybe<Scalars['Int']['input']>;
-  onlyOutcome?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyOutcome?: Scalars['Boolean']['input'];
   untilNode?: InputMaybe<Scalars['ID']['input']>;
 };
 
@@ -1576,14 +2094,53 @@ export type NodeMetricDimArgs = {
 
 export type NodeUpstreamActionsArgs = {
   decisionLevel?: InputMaybe<DecisionLevel>;
-  onlyRoot?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyRoot?: Scalars['Boolean']['input'];
 };
 
 
 export type NodeUpstreamNodesArgs = {
-  includeActions?: InputMaybe<Scalars['Boolean']['input']>;
-  sameQuantity?: InputMaybe<Scalars['Boolean']['input']>;
-  sameUnit?: InputMaybe<Scalars['Boolean']['input']>;
+  includeActions?: Scalars['Boolean']['input'];
+  sameQuantity?: Scalars['Boolean']['input'];
+  sameUnit?: Scalars['Boolean']['input'];
+};
+
+export type NodeConfigInput = {
+  action?: InputMaybe<ActionConfigInput>;
+  formula?: InputMaybe<FormulaConfigInput>;
+  pipeline?: InputMaybe<PipelineConfigInput>;
+  simple?: InputMaybe<SimpleConfigInput>;
+};
+
+export type NodeConfigUnion = ActionConfigType | FormulaConfigType | PipelineConfigType | SimpleConfigType;
+
+export type NodeEdgeType = EditableEntity & {
+  __typename?: 'NodeEdgeType';
+  /** Row-level change history for this edge, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
+  data: Array<DimensionalMetricType>;
+  fromRef: NodePortRef;
+  id: Scalars['ID']['output'];
+  tags: Array<Scalars['String']['output']>;
+  toRef: NodePortRef;
+  transformations: Array<EdgeTransformationUnion>;
+  uuid: Scalars['UUID']['output'];
+};
+
+
+export type NodeEdgeTypeChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
+};
+
+export type NodeEditor = {
+  __typename?: 'NodeEditor';
+  inputDimensions?: Maybe<Array<Scalars['String']['output']>>;
+  layoutMeta: NodeGraphLayoutMeta;
+  nodeGroup?: Maybe<Scalars['String']['output']>;
+  nodeType: Scalars['String']['output'];
+  outputDimensions?: Maybe<Array<Scalars['String']['output']>>;
+  spec?: Maybe<NodeSpecType>;
+  tags?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 export type NodeGoal = {
@@ -1592,47 +2149,75 @@ export type NodeGoal = {
   year: Scalars['Int']['output'];
 };
 
+export type NodeGraphLayoutMeta = {
+  __typename?: 'NodeGraphLayoutMeta';
+  avgOutgoingSpan: Scalars['Float']['output'];
+  canonicalRail?: Maybe<Scalars['String']['output']>;
+  ghostTargets: Array<Scalars['ID']['output']>;
+  ghostable: Scalars['Boolean']['output'];
+  hasActionAncestor: Scalars['Boolean']['output'];
+  inDegree: Scalars['Int']['output'];
+  isHub: Scalars['Boolean']['output'];
+  maxOutgoingSpan: Scalars['Int']['output'];
+  nodeId: Scalars['ID']['output'];
+  outDegree: Scalars['Int']['output'];
+  primaryClass: PrimaryLayoutClass;
+  topologicalLayer: Scalars['Int']['output'];
+  totalDegree: Scalars['Int']['output'];
+};
+
 export type NodeInterface = {
   body?: Maybe<Array<StreamFieldInterface>>;
+  /** Row-level change history for this node, newest first. */
+  changeHistory: Array<InstanceModelLogEntryType>;
   color?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   dimensionalFlow?: Maybe<DimensionalFlowType>;
   downstreamNodes: Array<NodeInterface>;
+  editor?: Maybe<NodeEditor>;
   explanation?: Maybe<Scalars['String']['output']>;
   goals: Array<NodeGoal>;
   id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
   impactMetric?: Maybe<ForecastMetricType>;
   impactMetrics: Array<ForecastMetricType>;
-  inputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   inputNodes: Array<NodeInterface>;
   /** @deprecated Use __typeName instead */
   isAction: Scalars['Boolean']['output'];
   isVisible: Scalars['Boolean']['output'];
+  kind?: Maybe<NodeKind>;
   metric?: Maybe<ForecastMetricType>;
   metricDim?: Maybe<DimensionalMetricType>;
   metrics?: Maybe<Array<ForecastMetricType>>;
   name: Scalars['String']['output'];
-  nodeType: Scalars['String']['output'];
   order?: Maybe<Scalars['Int']['output']>;
   outcome?: Maybe<DimensionalMetricType>;
-  outputDimensions?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   outputNodes: Array<NodeInterface>;
   parameters: Array<ParameterInterface>;
   quantity?: Maybe<Scalars['String']['output']>;
+  quantityKind?: Maybe<QuantityKindType>;
+  /** Stable UUID, populated for DB-backed nodes. Null for unsynced YAML nodes. */
+  resolveUuid?: Maybe<Scalars['UUID']['output']>;
   shortDescription?: Maybe<Scalars['RichText']['output']>;
   shortName?: Maybe<Scalars['String']['output']>;
-  tags?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** @deprecated Replaced by "goals". */
   targetYearGoal?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
   upstreamNodes: Array<NodeInterface>;
+  uuid: Scalars['UUID']['output'];
   visualizations?: Maybe<Array<VisualizationEntry>>;
+};
+
+
+export type NodeInterfaceChangeHistoryArgs = {
+  before?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: Scalars['Int']['input'];
 };
 
 
 export type NodeInterfaceDownstreamNodesArgs = {
   maxDepth?: InputMaybe<Scalars['Int']['input']>;
-  onlyOutcome?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyOutcome?: Scalars['Boolean']['input'];
   untilNode?: InputMaybe<Scalars['ID']['input']>;
 };
 
@@ -1660,9 +2245,29 @@ export type NodeInterfaceMetricDimArgs = {
 
 
 export type NodeInterfaceUpstreamNodesArgs = {
-  includeActions?: InputMaybe<Scalars['Boolean']['input']>;
-  sameQuantity?: InputMaybe<Scalars['Boolean']['input']>;
-  sameUnit?: InputMaybe<Scalars['Boolean']['input']>;
+  includeActions?: Scalars['Boolean']['input'];
+  sameQuantity?: Scalars['Boolean']['input'];
+  sameUnit?: Scalars['Boolean']['input'];
+};
+
+export enum NodeKind {
+  Action = 'ACTION',
+  Formula = 'FORMULA',
+  Pipeline = 'PIPELINE',
+  Simple = 'SIMPLE'
+}
+
+export type NodePortRef = {
+  __typename?: 'NodePortRef';
+  nodeId: Scalars['ID']['output'];
+  portId: Scalars['UUID']['output'];
+};
+
+export type NodeSpecType = {
+  __typename?: 'NodeSpecType';
+  inputPorts: Array<InputPortType>;
+  outputPorts: Array<OutputPortType>;
+  typeConfig: NodeConfigUnion;
 };
 
 export type NormalizationType = {
@@ -1688,20 +2293,46 @@ export type NumberParameterType = ParameterInterface & {
   isCustomizable: Scalars['Boolean']['output'];
   isCustomized: Scalars['Boolean']['output'];
   label?: Maybe<Scalars['String']['output']>;
-  /** ID of parameter in the node's namespace */
   localId?: Maybe<Scalars['ID']['output']>;
   maxValue?: Maybe<Scalars['Float']['output']>;
   minValue?: Maybe<Scalars['Float']['output']>;
   node?: Maybe<NodeInterface>;
+  /** ID of parameter in the node's namespace */
   nodeRelativeId?: Maybe<Scalars['ID']['output']>;
   step?: Maybe<Scalars['Float']['output']>;
   unit?: Maybe<UnitType>;
   value?: Maybe<Scalars['Float']['output']>;
 };
 
+export type OperationInfo = {
+  __typename?: 'OperationInfo';
+  /** List of messages returned by the operation. */
+  messages: Array<OperationMessage>;
+};
+
+export type OperationMessage = {
+  __typename?: 'OperationMessage';
+  /** The error code, or `null` if no error code was set. */
+  code?: Maybe<Scalars['String']['output']>;
+  /** The field that caused the error, or `null` if it isn't associated with any particular field. */
+  field?: Maybe<Scalars['String']['output']>;
+  /** The kind of this message. */
+  kind: OperationMessageKind;
+  /** The error message. */
+  message: Scalars['String']['output'];
+};
+
+export enum OperationMessageKind {
+  Error = 'ERROR',
+  Info = 'INFO',
+  Permission = 'PERMISSION',
+  Validation = 'VALIDATION',
+  Warning = 'WARNING'
+}
+
 export type Organization = {
   __typename?: 'Organization';
-  /** A simplified short version of name for the general public */
+  /** Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name */
   abbreviation?: Maybe<Scalars['String']['output']>;
   adminButtons: Array<AdminButton>;
   ancestors?: Maybe<Array<Maybe<Organization>>>;
@@ -1711,10 +2342,10 @@ export type Organization = {
   distinctName?: Maybe<Scalars['String']['output']>;
   email: Scalars['String']['output'];
   id: Scalars['ID']['output'];
-  location?: Maybe<Scalars['PointScalar']['output']>;
-  /** A primary name, e.g. a legally recognized name */
+  /** Full name of the organization */
   name: Scalars['String']['output'];
   parent?: Maybe<Organization>;
+  path: Scalars['String']['output'];
   url: Scalars['String']['output'];
   userPermissions?: Maybe<UserPermissions>;
   userRoles?: Maybe<Array<Scalars['String']['output']>>;
@@ -1744,6 +2375,7 @@ export type OutcomePage = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   outcomeNode: Node;
   owner?: Maybe<UserType>;
@@ -1751,9 +2383,12 @@ export type OutcomePage = PageInterface & {
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
+  /** Should the page be shown in the additional links? */
+  showInAdditionalLinks: Scalars['Boolean']['output'];
   showInFooter?: Maybe<Scalars['Boolean']['output']>;
   showInMenus: Scalars['Boolean']['output'];
   siblings: Array<PageInterface>;
@@ -1765,28 +2400,9 @@ export type OutcomePage = PageInterface & {
 };
 
 
-export type OutcomePageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type OutcomePageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type OutcomePageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -1794,14 +2410,35 @@ export type OutcomePageDescendantsArgs = {
   searchQuery?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type OutputMetricInput = {
+  columnId?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['String']['input'];
+  label?: InputMaybe<Scalars['String']['input']>;
+  portId?: InputMaybe<Scalars['UUID']['input']>;
+  quantity?: InputMaybe<Scalars['String']['input']>;
+  unit: Scalars['String']['input'];
+};
 
-export type OutcomePageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
+export type OutputPortInput = {
+  columnId?: InputMaybe<Scalars['String']['input']>;
+  dimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  id?: InputMaybe<Scalars['UUID']['input']>;
+  isEditable?: Scalars['Boolean']['input'];
+  label?: InputMaybe<Scalars['String']['input']>;
+  quantity?: InputMaybe<Scalars['String']['input']>;
+  unit: Scalars['String']['input'];
+};
+
+export type OutputPortType = {
+  __typename?: 'OutputPortType';
+  columnId?: Maybe<Scalars['String']['output']>;
+  dimensions: Array<Scalars['String']['output']>;
+  edges: Array<NodeEdgeType>;
+  id: Scalars['UUID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  output?: Maybe<DimensionalMetricType>;
+  quantity?: Maybe<Scalars['String']['output']>;
+  unit: UnitType;
 };
 
 /**
@@ -1833,12 +2470,14 @@ export type Page = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   outcomepage?: Maybe<OutcomePage>;
   owner?: Maybe<UserType>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
@@ -1858,50 +2497,9 @@ export type Page = PageInterface & {
  * Base Page type used if one isn't generated for the current model.
  * All other node types extend this.
  */
-export type PageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/**
- * Base Page type used if one isn't generated for the current model.
- * All other node types extend this.
- */
-export type PageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/**
- * Base Page type used if one isn't generated for the current model.
- * All other node types extend this.
- */
 export type PageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-/**
- * Base Page type used if one isn't generated for the current model.
- * All other node types extend this.
- */
-export type PageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -1929,8 +2527,10 @@ export type PageInterface = {
   lastPublishedAt?: Maybe<Scalars['DateTime']['output']>;
   live: Scalars['Boolean']['output'];
   locked?: Maybe<Scalars['Boolean']['output']>;
+  nextSiblings: Array<PageInterface>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
@@ -1943,38 +2543,9 @@ export type PageInterface = {
 };
 
 
-export type PageInterfaceAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type PageInterfaceChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type PageInterfaceDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type PageInterfaceSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -1989,16 +2560,57 @@ export type ParameterInterface = {
   isCustomizable: Scalars['Boolean']['output'];
   isCustomized: Scalars['Boolean']['output'];
   label?: Maybe<Scalars['String']['output']>;
-  /** ID of parameter in the node's namespace */
   localId?: Maybe<Scalars['ID']['output']>;
   node?: Maybe<NodeInterface>;
+  /** ID of parameter in the node's namespace */
   nodeRelativeId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type PipelineConfigInput = {
+  operations?: Array<PipelineOperationInput>;
+};
+
+export type PipelineConfigType = {
+  __typename?: 'PipelineConfigType';
+  operations: Scalars['JSON']['output'];
+};
+
+export type PipelineOperationInput = {
+  operation: Scalars['String']['input'];
 };
 
 export type PlaceHolderDataPoint = {
   __typename?: 'PlaceHolderDataPoint';
   value?: Maybe<Scalars['Float']['output']>;
   year?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Which slice of an instance to resolve. `PUBLISHED` (default) serves the latest published revision; `DRAFT` serves the editor's in-progress state and requires edit permission on the instance. */
+export enum PreviewMode {
+  Draft = 'DRAFT',
+  Published = 'PUBLISHED'
+}
+
+export enum PrimaryLayoutClass {
+  Action = 'ACTION',
+  ContextSource = 'CONTEXT_SOURCE',
+  Core = 'CORE',
+  GhostableContextSource = 'GHOSTABLE_CONTEXT_SOURCE',
+  Outcome = 'OUTCOME'
+}
+
+export type PublishModelInstancePayload = InstanceType | OperationInfo;
+
+export type QuantityKindType = {
+  __typename?: 'QuantityKindType';
+  icon?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  isActivity: Scalars['Boolean']['output'];
+  isFactor: Scalars['Boolean']['output'];
+  isStackable: Scalars['Boolean']['output'];
+  isUnitPrice: Scalars['Boolean']['output'];
+  label: Scalars['String']['output'];
+  qudtIri?: Maybe<Scalars['String']['output']>;
 };
 
 export type Query = {
@@ -2017,8 +2629,10 @@ export type Query = {
   frameworks?: Maybe<Array<Framework>>;
   impactOverviews: Array<ImpactOverviewType>;
   instance: InstanceType;
-  instanceOrganizations?: Maybe<Array<Organization>>;
+  instanceOrganizations: Array<Organization>;
   me?: Maybe<UserType>;
+  /** Fetch a complete model instance with all nodes, edges, and scenarios */
+  modelInstance: InstanceType;
   node?: Maybe<NodeInterface>;
   nodes: Array<NodeInterface>;
   organization?: Maybe<Organization>;
@@ -2026,10 +2640,10 @@ export type Query = {
   pages: Array<PageInterface>;
   parameter?: Maybe<ParameterInterface>;
   parameters: Array<ParameterInterface>;
-  scenario?: Maybe<ScenarioType>;
+  scenario: ScenarioType;
   scenarios: Array<ScenarioType>;
   serverDeployment: ServerDeployment;
-  unit?: Maybe<UnitType>;
+  unit: UnitType;
 };
 
 
@@ -2039,7 +2653,7 @@ export type QueryActionArgs = {
 
 
 export type QueryActionsArgs = {
-  onlyRoot?: InputMaybe<Scalars['Boolean']['input']>;
+  onlyRoot?: Scalars['Boolean']['input'];
 };
 
 
@@ -2055,7 +2669,12 @@ export type QueryFrameworkArgs = {
 
 export type QueryInstanceOrganizationsArgs = {
   instance?: InputMaybe<Scalars['ID']['input']>;
-  withAncestors?: InputMaybe<Scalars['Boolean']['input']>;
+  withAncestors?: Scalars['Boolean']['input'];
+};
+
+
+export type QueryModelInstanceArgs = {
+  instanceId: Scalars['ID']['input'];
 };
 
 
@@ -2075,6 +2694,8 @@ export type QueryPageArgs = {
 
 
 export type QueryPagesArgs = {
+  inAdditionalLinks?: InputMaybe<Scalars['Boolean']['input']>;
+  inFooter?: InputMaybe<Scalars['Boolean']['input']>;
   inMenu?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -2124,9 +2745,25 @@ export type RegexBlock = StreamFieldInterface & {
   value: Scalars['String']['output'];
 };
 
-export type ResetParameterMutation = {
-  __typename?: 'ResetParameterMutation';
-  ok?: Maybe<Scalars['Boolean']['output']>;
+export type RegisterUserInput = {
+  email: Scalars['String']['input'];
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  frameworkId: Scalars['String']['input'];
+  lastName?: InputMaybe<Scalars['String']['input']>;
+  password: Scalars['String']['input'];
+};
+
+export type RegisterUserPayload = OperationInfo | RegisterUserResult;
+
+export type RegisterUserResult = {
+  __typename?: 'RegisterUserResult';
+  email: Scalars['String']['output'];
+  userId: Scalars['ID']['output'];
+};
+
+export type ResetParameterResult = {
+  __typename?: 'ResetParameterResult';
+  ok: Scalars['Boolean']['output'];
 };
 
 export type RichTextBlock = StreamFieldInterface & {
@@ -2144,13 +2781,18 @@ export type ScenarioActionImpacts = {
   scenario: ScenarioType;
 };
 
-/** An enumeration. */
 export enum ScenarioKind {
   Baseline = 'BASELINE',
   Custom = 'CUSTOM',
   Default = 'DEFAULT',
   ProgressTracking = 'PROGRESS_TRACKING'
 }
+
+export type ScenarioParameterOverrideType = {
+  __typename?: 'ScenarioParameterOverrideType';
+  parameterId: Scalars['String']['output'];
+  value: Scalars['JSON']['output'];
+};
 
 export type ScenarioProgressBarBlock = StreamFieldInterface & {
   __typename?: 'ScenarioProgressBarBlock';
@@ -2169,12 +2811,16 @@ export type ScenarioProgressBarBlock = StreamFieldInterface & {
 export type ScenarioType = {
   __typename?: 'ScenarioType';
   actualHistoricalYears?: Maybe<Array<Scalars['Int']['output']>>;
+  allActionsEnabled: Scalars['Boolean']['output'];
+  description?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  identifier: Scalars['String']['output'];
   isActive: Scalars['Boolean']['output'];
   isDefault: Scalars['Boolean']['output'];
   isSelectable: Scalars['Boolean']['output'];
   kind?: Maybe<ScenarioKind>;
   name: Scalars['String']['output'];
+  parameterOverrides: Array<ScenarioParameterOverrideType>;
 };
 
 export type ScenarioValue = {
@@ -2217,6 +2863,21 @@ export type Section = {
   uuid: Scalars['UUID']['output'];
 };
 
+export type SelectCategoriesTransformationInput = {
+  categories?: Array<Scalars['String']['input']>;
+  dimension: Scalars['String']['input'];
+  exclude?: Scalars['Boolean']['input'];
+  flatten?: Scalars['Boolean']['input'];
+};
+
+export type SelectCategoriesTransformationType = {
+  __typename?: 'SelectCategoriesTransformationType';
+  categories: Array<Scalars['String']['output']>;
+  dimension: Scalars['String']['output'];
+  exclude: Scalars['Boolean']['output'];
+  flatten: Scalars['Boolean']['output'];
+};
+
 export type ServerDeployment = {
   __typename?: 'ServerDeployment';
   buildId?: Maybe<Scalars['String']['output']>;
@@ -2224,16 +2885,33 @@ export type ServerDeployment = {
   gitRevision?: Maybe<Scalars['String']['output']>;
 };
 
+export type SetInstanceLockedPayload = OperationInfo | SetInstanceLockedResult;
+
+export type SetInstanceLockedResult = {
+  __typename?: 'SetInstanceLockedResult';
+  instanceId: Scalars['ID']['output'];
+  isLocked: Scalars['Boolean']['output'];
+};
+
 export type SetNormalizerMutation = {
   __typename?: 'SetNormalizerMutation';
-  activeNormalizer: NormalizationType;
+  activeNormalizer?: Maybe<NormalizationType>;
   ok: Scalars['Boolean']['output'];
 };
 
-export type SetParameterMutation = {
-  __typename?: 'SetParameterMutation';
-  ok?: Maybe<Scalars['Boolean']['output']>;
+export type SetParameterResult = {
+  __typename?: 'SetParameterResult';
+  ok: Scalars['Boolean']['output'];
   parameter?: Maybe<ParameterInterface>;
+};
+
+export type SimpleConfigInput = {
+  nodeClass: Scalars['String']['input'];
+};
+
+export type SimpleConfigType = {
+  __typename?: 'SimpleConfigType';
+  nodeClass: Scalars['String']['output'];
 };
 
 export type SiteObjectType = {
@@ -2317,14 +2995,17 @@ export type StaticPage = PageInterface & {
   locked?: Maybe<Scalars['Boolean']['output']>;
   lockedAt?: Maybe<Scalars['DateTime']['output']>;
   lockedBy?: Maybe<UserType>;
+  nextSiblings: Array<PageInterface>;
   numchild: Scalars['Int']['output'];
   owner?: Maybe<UserType>;
   pageType?: Maybe<Scalars['String']['output']>;
   parent?: Maybe<PageInterface>;
   path: Scalars['String']['output'];
+  previousSiblings: Array<PageInterface>;
   searchDescription?: Maybe<Scalars['String']['output']>;
   searchScore?: Maybe<Scalars['Float']['output']>;
   seoTitle: Scalars['String']['output'];
+  showInAdditionalLinks: Scalars['Boolean']['output'];
   showInFooter: Scalars['Boolean']['output'];
   showInMenus: Scalars['Boolean']['output'];
   siblings: Array<PageInterface>;
@@ -2336,38 +3017,9 @@ export type StaticPage = PageInterface & {
 };
 
 
-export type StaticPageAncestorsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type StaticPageChildrenArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
 export type StaticPageDescendantsArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
-  limit?: InputMaybe<Scalars['PositiveInt']['input']>;
-  offset?: InputMaybe<Scalars['PositiveInt']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  searchOperator?: InputMaybe<SearchOperatorEnum>;
-  searchQuery?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type StaticPageSiblingsArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
+  inMenu?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['PositiveInt']['input']>;
   offset?: InputMaybe<Scalars['PositiveInt']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -2409,9 +3061,9 @@ export type StringParameterType = ParameterInterface & {
   isCustomizable: Scalars['Boolean']['output'];
   isCustomized: Scalars['Boolean']['output'];
   label?: Maybe<Scalars['String']['output']>;
-  /** ID of parameter in the node's namespace */
   localId?: Maybe<Scalars['ID']['output']>;
   node?: Maybe<NodeInterface>;
+  /** ID of parameter in the node's namespace */
   nodeRelativeId?: Maybe<Scalars['ID']['output']>;
   value?: Maybe<Scalars['String']['output']>;
 };
@@ -2480,10 +3132,18 @@ export type UrlBlock = StreamFieldInterface & {
   value: Scalars['String']['output'];
 };
 
+export type UnitDimensionality = {
+  __typename?: 'UnitDimensionality';
+  dimension: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
 export type UnitType = {
   __typename?: 'UnitType';
+  dimensionality: Array<UnitDimensionality>;
   htmlLong: Scalars['String']['output'];
   htmlShort: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
   long: Scalars['String']['output'];
   short: Scalars['String']['output'];
   standard: Scalars['String']['output'];
@@ -2497,11 +3157,37 @@ export type UnknownParameterType = ParameterInterface & {
   isCustomizable: Scalars['Boolean']['output'];
   isCustomized: Scalars['Boolean']['output'];
   label?: Maybe<Scalars['String']['output']>;
-  /** ID of parameter in the node's namespace */
   localId?: Maybe<Scalars['ID']['output']>;
   node?: Maybe<NodeInterface>;
+  /** ID of parameter in the node's namespace */
   nodeRelativeId?: Maybe<Scalars['ID']['output']>;
 };
+
+export type UpdateDataPointInput = {
+  date?: InputMaybe<Scalars['Date']['input']>;
+  dimensionCategoryIds?: InputMaybe<Array<Scalars['UUID']['input']>>;
+  metricId?: InputMaybe<Scalars['UUID']['input']>;
+  value?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type UpdateDataPointPayload = DataPoint | OperationInfo;
+
+export type UpdateDimensionCategoriesPayload = InstanceDimension | OperationInfo;
+
+export type UpdateDimensionCategoryInput = {
+  categoryId: Scalars['UUID']['input'];
+  identifier?: InputMaybe<Scalars['String']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  nextSibling?: InputMaybe<Scalars['ID']['input']>;
+  previousSibling?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type UpdateDimensionInput = {
+  dimensionId: Scalars['UUID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateDimensionPayload = InstanceDimension | OperationInfo;
 
 export type UpdateFrameworkConfigMutation = {
   __typename?: 'UpdateFrameworkConfigMutation';
@@ -2523,27 +3209,41 @@ export type UpdateMeasureDataPoints = {
   updatedDataPoints?: Maybe<Array<Maybe<MeasureDataPoint>>>;
 };
 
-export type UpdateOrganizationMutationInput = {
-  /** A simplified short version of name for the general public */
-  abbreviation?: InputMaybe<Scalars['String']['input']>;
-  classification?: InputMaybe<Scalars['ID']['input']>;
-  clientMutationId?: InputMaybe<Scalars['String']['input']>;
-  /** A date of dissolution */
-  dissolutionDate?: InputMaybe<Scalars['Date']['input']>;
-  /** A date of founding */
-  foundingDate?: InputMaybe<Scalars['Date']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  /** A primary name, e.g. a legally recognized name */
-  name: Scalars['String']['input'];
-  parent?: InputMaybe<Scalars['ID']['input']>;
+export type UpdateNodeInput = {
+  allowNulls?: InputMaybe<Scalars['Boolean']['input']>;
+  color?: InputMaybe<Scalars['String']['input']>;
+  config?: InputMaybe<NodeConfigInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  i18n?: InputMaybe<Scalars['JSON']['input']>;
+  inputDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  inputPorts?: InputMaybe<Array<InputPortInput>>;
+  isOutcome?: InputMaybe<Scalars['Boolean']['input']>;
+  isVisible?: InputMaybe<Scalars['Boolean']['input']>;
+  kind?: InputMaybe<NodeKind>;
+  minimumYear?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nodeGroup?: InputMaybe<Scalars['ID']['input']>;
+  order?: InputMaybe<Scalars['Int']['input']>;
+  outputDimensions?: InputMaybe<Array<Scalars['String']['input']>>;
+  outputMetrics?: InputMaybe<Array<OutputMetricInput>>;
+  outputPorts?: InputMaybe<Array<OutputPortInput>>;
+  params?: InputMaybe<Scalars['JSON']['input']>;
+  shortName?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
-export type UpdateOrganizationMutationPayload = {
-  __typename?: 'UpdateOrganizationMutationPayload';
-  clientMutationId?: Maybe<Scalars['String']['output']>;
-  errors: Array<ErrorType>;
-  organization?: Maybe<Organization>;
+export type UpdateNodePayload = ActionNode | Node | OperationInfo;
+
+export type UpdateScenarioInput = {
+  allActionsEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  kind?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  parameterOverrides?: InputMaybe<Scalars['JSON']['input']>;
+  scenarioId: Scalars['ID']['input'];
 };
+
+export type UpdateScenarioPayload = OperationInfo | ScenarioType;
 
 export type UserFrameworkRole = {
   __typename?: 'UserFrameworkRole';
@@ -2615,6 +3315,15 @@ export type YearlyValue = {
   __typename?: 'YearlyValue';
   value: Scalars['Float']['output'];
   year: Scalars['Int']['output'];
+};
+
+export type YearsDefType = {
+  __typename?: 'YearsDefType';
+  maxHistorical?: Maybe<Scalars['Int']['output']>;
+  minHistorical?: Maybe<Scalars['Int']['output']>;
+  modelEnd?: Maybe<Scalars['Int']['output']>;
+  reference?: Maybe<Scalars['Int']['output']>;
+  target?: Maybe<Scalars['Int']['output']>;
 };
 
 export type _Service = {
@@ -2718,7 +3427,7 @@ export type GetFrameworkConfigQueryVariables = Exact<{
 export type GetFrameworkConfigQuery = (
   { framework?: (
     { id: string, config?: (
-      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, locked?: boolean | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, instanceIdentifier: string, isLocked: boolean }
       & { __typename?: 'FrameworkConfig' }
     ) | null }
     & { __typename?: 'Framework' }
@@ -2732,7 +3441,7 @@ export type GetFrameworkConfigsQueryVariables = Exact<{ [key: string]: never; }>
 export type GetFrameworkConfigsQuery = (
   { framework?: (
     { id: string, configs: Array<(
-      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, locked?: boolean | null }
+      { id: string, organizationName?: string | null, baselineYear: number, targetYear?: number | null, viewUrl?: string | null, resultsDownloadUrl?: string | null, instanceIdentifier: string, isLocked: boolean }
       & { __typename?: 'FrameworkConfig' }
     )> }
     & { __typename?: 'Framework' }
@@ -2758,6 +3467,17 @@ export type GetFrameworkSettingsQuery = (
     & { __typename?: 'Framework' }
   ) | null }
   & { __typename?: 'Query' }
+);
+
+export type SetInstanceLockedMutationVariables = Exact<{
+  instanceId: Scalars['ID']['input'];
+  isLocked: Scalars['Boolean']['input'];
+}>;
+
+
+export type SetInstanceLockedMutation = (
+  { setInstanceLocked: { __typename: 'OperationInfo' | 'SetInstanceLockedResult' } }
+  & { __typename?: 'Mutation' }
 );
 
 export type GetMeasureTemplateQueryVariables = Exact<{

--- a/src/types/__generated__/possible_types.json
+++ b/src/types/__generated__/possible_types.json
@@ -1,5 +1,59 @@
 {
   "possibleTypes": {
+    "AddNodeInputPortPayload": [
+      "InputPortType",
+      "OperationInfo"
+    ],
+    "AddNodeOutputPortPayload": [
+      "OperationInfo",
+      "OutputPortType"
+    ],
+    "CreateDataPointPayload": [
+      "DataPoint",
+      "OperationInfo"
+    ],
+    "CreateDimensionCategoriesPayload": [
+      "InstanceDimension",
+      "OperationInfo"
+    ],
+    "CreateEdgePayload": [
+      "NodeEdgeType",
+      "OperationInfo"
+    ],
+    "CreateInstancePayload": [
+      "CreateInstanceResult",
+      "OperationInfo"
+    ],
+    "CreateNodePayload": [
+      "ActionNode",
+      "Node",
+      "OperationInfo"
+    ],
+    "CreateScenarioPayload": [
+      "OperationInfo",
+      "ScenarioType"
+    ],
+    "EdgeTransformationUnion": [
+      "AssignCategoryTransformationType",
+      "FlattenTransformationType",
+      "SelectCategoriesTransformationType"
+    ],
+    "EditableEntity": [
+      "ActionNode",
+      "DatasetPortType",
+      "Node",
+      "NodeEdgeType"
+    ],
+    "InputPortBindingUnion": [
+      "DatasetPortType",
+      "NodeEdgeType"
+    ],
+    "NodeConfigUnion": [
+      "ActionConfigType",
+      "FormulaConfigType",
+      "PipelineConfigType",
+      "SimpleConfigType"
+    ],
     "NodeInterface": [
       "ActionNode",
       "Node"
@@ -17,6 +71,18 @@
       "NumberParameterType",
       "StringParameterType",
       "UnknownParameterType"
+    ],
+    "PublishModelInstancePayload": [
+      "InstanceType",
+      "OperationInfo"
+    ],
+    "RegisterUserPayload": [
+      "OperationInfo",
+      "RegisterUserResult"
+    ],
+    "SetInstanceLockedPayload": [
+      "OperationInfo",
+      "SetInstanceLockedResult"
     ],
     "SnippetInterface": [
       "InstanceSiteContent"
@@ -39,6 +105,7 @@
       "EmailBlock",
       "EmbedBlock",
       "FloatBlock",
+      "FrameworkLandingBlock",
       "GoalProgressBarBlock",
       "ImageBlock",
       "ImageChooserBlock",
@@ -58,6 +125,27 @@
       "TextBlock",
       "TimeBlock",
       "URLBlock"
+    ],
+    "UpdateDataPointPayload": [
+      "DataPoint",
+      "OperationInfo"
+    ],
+    "UpdateDimensionCategoriesPayload": [
+      "InstanceDimension",
+      "OperationInfo"
+    ],
+    "UpdateDimensionPayload": [
+      "InstanceDimension",
+      "OperationInfo"
+    ],
+    "UpdateNodePayload": [
+      "ActionNode",
+      "Node",
+      "OperationInfo"
+    ],
+    "UpdateScenarioPayload": [
+      "OperationInfo",
+      "ScenarioType"
     ],
     "VisualizationEntry": [
       "VisualizationGroup",

--- a/src/utils/tests.tsx
+++ b/src/utils/tests.tsx
@@ -1,16 +1,30 @@
 import type { ReactNode } from 'react';
 import type React from 'react';
-import type { RenderOptions, RenderResult} from '@testing-library/react';
+import type { RenderOptions, RenderResult } from '@testing-library/react';
 import { render } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import type { MockedResponse } from '@apollo/client/testing';
 
-const Providers = ({ children }: { children: ReactNode }) => {
-  return children;
+import { SnackbarProvider } from '@/components/SnackbarProvider';
+
+type CustomRenderOptions = Omit<RenderOptions, 'queries'> & {
+  mocks?: MockedResponse[];
 };
+
+const Providers = ({ children, mocks }: { children: ReactNode; mocks?: MockedResponse[] }) => (
+  <MockedProvider mocks={mocks ?? []} addTypename={false}>
+    <SnackbarProvider>{children}</SnackbarProvider>
+  </MockedProvider>
+);
+
 function customRender(
   ui: React.ReactNode,
-  options: Omit<RenderOptions, 'queries'> = {}
+  { mocks, ...options }: CustomRenderOptions = {}
 ): RenderResult {
-  return render(ui, { wrapper: Providers, ...options });
+  return render(ui, {
+    wrapper: ({ children }) => <Providers mocks={mocks}>{children}</Providers>,
+    ...options,
+  });
 }
 
 export * from '@testing-library/react';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "./kausal_common/configs/tsconfig.json",
+  "ts-node": {
+    "compilerOptions": {
+      "verbatimModuleSyntax": false
+    }
+  },
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Description
Update the "Create new plan" button to a dropdown menu that allows users to:
- Create a new plan
- Lock a plan
- Delete a plan

## Screenshots/Videos (if applicable)
https://kausaltech.slack.com/archives/C095SGKMS6M/p1777019484978559?thread_ts=1777017384.209419&cid=C095SGKMS6M

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213132526701358?focus=true

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Authorization is tested** (permissions and access controls verified)
- [x] **Mobile screen widths tested for responsiveness** (if applicable)
- [x] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs)
