### PR TITLE
Improve loading states

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -49,7 +49,7 @@ export default function HomeLayout({ children }: Props) {
     }
   }, [status, router]);
 
-  if (!isAuthenticated && status === 'loading') {
+  if (!isAuthenticated) {
     return <Loading />;
   }
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -147,6 +147,17 @@ export default function DashboardContent() {
     return <Loading />;
   }
 
+  if (permissions.isLoading) {
+    return (
+      <Container>
+        <Stack spacing={4}>
+          <Skeleton variant="rounded" height={150} />
+          <LoadingCard />
+        </Stack>
+      </Container>
+    );
+  }
+
   if (allPlans.length === 0) {
     return (
       <Fade in>
@@ -159,7 +170,13 @@ export default function DashboardContent() {
                 </Typography>
                 <Typography variant="subtitle1" sx={{ maxWidth: '80%' }}>
                   It looks like there aren't any plans for your city yet.{' '}
-                  {!permissions.create ? (
+                  {permissions.isLoading ? (
+                    <Skeleton
+                      variant="text"
+                      width="60%"
+                      sx={{ display: 'inline-block', verticalAlign: 'middle' }}
+                    />
+                  ) : !permissions.create ? (
                     <>
                       You don't currently have permission to create one. To request edit access,
                       please fill out{' '}

--- a/src/components/InstanceControlBar.tsx
+++ b/src/components/InstanceControlBar.tsx
@@ -17,6 +17,7 @@ import {
   MenuItem,
   Link as MuiLink,
   Select,
+  Skeleton,
   Stack,
   Tooltip,
   Typography,
@@ -141,7 +142,7 @@ function getNavStyles(isActive: boolean): SxProps<Theme> {
 export function InstanceControlBar() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [isRequestEditTooltipOpen, setIsRequestEditTooltipOpen] = useState(true); // Initially true, but will only be shown if the user has no create permissions
+  const [isRequestEditTooltipOpen, setIsRequestEditTooltipOpen] = useState(false);
 
   const permissions = usePermissions();
 
@@ -233,7 +234,13 @@ export function InstanceControlBar() {
             </Stack>
           )}
 
-          <Stack direction="row" justifyContent="flex-end" ml="auto" spacing={1}>
+          <Stack
+            direction="row"
+            justifyContent="flex-end"
+            ml="auto"
+            alignItems="center"
+            spacing={1}
+          >
             {hasMultipleInstances && plan?.id && (
               <InstanceSelector
                 selectedInstanceId={plan.id}
@@ -241,7 +248,9 @@ export function InstanceControlBar() {
                 onInstanceChange={setSelectedPlanId}
               />
             )}
-            {!permissions.isLoading && plan && (permissions.create || permissions.isAdmin) && (
+            {permissions.isLoading ? (
+              <Skeleton variant="rounded" width={80} height={36} />
+            ) : plan && (permissions.create || permissions.isAdmin) ? (
               <PlanActionsMenu
                 planId={plan.id}
                 instanceIdentifier={plan.instanceIdentifier}
@@ -252,8 +261,7 @@ export function InstanceControlBar() {
                 onCreateClick={() => setIsAddModalOpen(true)}
                 onDeleteClick={() => setIsDeleteDialogOpen(true)}
               />
-            )}
-            {!permissions.isLoading && (!plan || (!permissions.create && !permissions.isAdmin)) && (
+            ) : (
               <>
                 {permissions.create ? (
                   <Button onClick={() => setIsAddModalOpen(true)} variant="outlined">


### PR DESCRIPTION
## Description
As the app has evolved the loading states became a bit messy, causing some state flickering and content jumps.

This prevents several instances of content flashing/ jumping during initial page load:

1. Instance select bar: Show a skeleton while permissions are loading. Previously a disabled "Create new plan" button flashed (with tooltip) briefly before permissions confirmed the user has access.
2. Main content: A content skeleton now shows while permissions load, so the control bar and main content reveal real UI at the same time rather than the content area snapping in weirdly.
3. Unauthenticated main content: The home layout now blocks rendering until isAuthenticated is true (previously only blocked during status loading), which mean the instance select bar briefly appeared for unauthenticated users before the redirect to /welcome.

