### PR TITLE
Fix plan not being selected upon create

### DIFF
--- a/src/components/providers/SelectedPlanProvider.tsx
+++ b/src/components/providers/SelectedPlanProvider.tsx
@@ -92,7 +92,7 @@ export function SelectedPlanProvider({ children, plan: initialPlan }: Props) {
   };
 
   const firstPlan = data?.framework?.configs[0];
-  if (firstPlan && !selectedPlan) {
+  if (firstPlan && !planId) {
     setSelectedPlanId(firstPlan.id);
     logger.info(
       { 'initial-plan': initialPlan, 'plan-id': planId, 'first-plan-id': firstPlan.id },


### PR DESCRIPTION
When creating a new plan, it wasn't immediately selected as the active plan upon creation. This is because the plan cache updates after the `SelectedPlanProvider` rerenders, fails to find the updated plan from the cache, and selects a plan from the list instead.

Since we know a plan exists under `planId`, check against that rather than the `selectedPlan`