### PR TITLE
Add warnings for abnormal values

### DIFF
--- a/src/components/AdditionalDatasheetEditor.tsx
+++ b/src/components/AdditionalDatasheetEditor.tsx
@@ -47,12 +47,12 @@ import { HelpText } from './HelpText';
 import { useSnackbar } from './SnackbarProvider';
 import { usePlans, useSuspenseSelectedPlanConfig } from './providers/SelectedPlanProvider';
 
-type SuggestedBounds = { minValue: number | null; maxValue: number | null };
+type ProbableBounds = { probableLowerBound: number | null; probableUpperBound: number | null };
 
 type AdditionalDatasheetMeasureRow = BaseMeasureRow & {
   baselineValue: number | null;
   placeholderDataPoints: Record<number, null | number>;
-  suggestedBoundsByYear: Record<number, SuggestedBounds>;
+  probableBoundsByYear: Record<number, ProbableBounds>;
   [year: number]: null | number;
 };
 
@@ -166,15 +166,15 @@ function getRowsFromSection(
         unit: measure.unit,
         depth: depth + 1,
         originalMeasureTemplate: measure,
-        suggestedMinValue: null,
-        suggestedMaxValue: null,
-        suggestedBoundsByYear:
-          measure.measure?.dataPoints.reduce<Record<number, SuggestedBounds>>(
-            (acc, dp) => ({
+        probableLowerBound: null,
+        probableUpperBound: null,
+        probableBoundsByYear:
+          measure.measure?.dataPoints.reduce<Record<number, ProbableBounds>>(
+            (acc, dataPoint) => ({
               ...acc,
-              [dp.year]: {
-                minValue: 200, // || dp.minValue ?? null, TODO: Update when backend ready
-                maxValue: 2000, // ||dp.maxValue ?? null TODO: Update when backend ready
+              [dataPoint.year]: {
+                probableLowerBound: dataPoint.probableLowerBound ?? null,
+                probableUpperBound: dataPoint.probableUpperBound ?? null,
               },
             }),
             {}
@@ -491,11 +491,11 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
                 );
               }
 
-              const bounds = row.suggestedBoundsByYear[year];
+              const bounds = row.probableBoundsByYear[year];
               const rowWithBounds = {
                 ...row,
-                suggestedMinValue: bounds?.minValue ?? null,
-                suggestedMaxValue: bounds?.maxValue ?? null,
+                probableLowerBound: bounds?.probableLowerBound ?? null,
+                probableUpperBound: bounds?.probableUpperBound ?? null,
               };
               return (
                 <CustomEditComponent<AdditionalDatasheetMeasureRow>
@@ -511,11 +511,11 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
                 return null;
               }
 
-              const bounds = row.suggestedBoundsByYear[year];
+              const bounds = row.probableBoundsByYear[year];
               const rowWithBounds = {
                 ...row,
-                suggestedMinValue: bounds?.minValue ?? null,
-                suggestedMaxValue: bounds?.maxValue ?? null,
+                probableLowerBound: bounds?.probableLowerBound ?? null,
+                probableUpperBound: bounds?.probableUpperBound ?? null,
               };
               return (
                 <CustomEditComponent<AdditionalDatasheetMeasureRow>

--- a/src/components/AdditionalDatasheetEditor.tsx
+++ b/src/components/AdditionalDatasheetEditor.tsx
@@ -47,9 +47,12 @@ import { HelpText } from './HelpText';
 import { useSnackbar } from './SnackbarProvider';
 import { usePlans, useSuspenseSelectedPlanConfig } from './providers/SelectedPlanProvider';
 
+type SuggestedBounds = { minValue: number | null; maxValue: number | null };
+
 type AdditionalDatasheetMeasureRow = BaseMeasureRow & {
   baselineValue: number | null;
   placeholderDataPoints: Record<number, null | number>;
+  suggestedBoundsByYear: Record<number, SuggestedBounds>;
   [year: number]: null | number;
 };
 
@@ -163,6 +166,19 @@ function getRowsFromSection(
         unit: measure.unit,
         depth: depth + 1,
         originalMeasureTemplate: measure,
+        suggestedMinValue: null,
+        suggestedMaxValue: null,
+        suggestedBoundsByYear:
+          measure.measure?.dataPoints.reduce<Record<number, SuggestedBounds>>(
+            (acc, dp) => ({
+              ...acc,
+              [dp.year]: {
+                minValue: 200, // || dp.minValue ?? null, TODO: Update when backend ready
+                maxValue: 2000, // ||dp.maxValue ?? null TODO: Update when backend ready
+              },
+            }),
+            {}
+          ) ?? {},
         placeholderDataPoints:
           measure.measure?.placeholderDataPoints?.reduce(
             reduceDataPoints,
@@ -475,10 +491,16 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
                 );
               }
 
+              const bounds = row.suggestedBoundsByYear[year];
+              const rowWithBounds = {
+                ...row,
+                suggestedMinValue: bounds?.minValue ?? null,
+                suggestedMaxValue: bounds?.maxValue ?? null,
+              };
               return (
                 <CustomEditComponent<AdditionalDatasheetMeasureRow>
                   {...rest}
-                  row={row}
+                  row={rowWithBounds}
                   sx={{ mx: 0, my: 1 }}
                   placeholder={getPlaceholder(params.row, year)}
                 />
@@ -489,10 +511,16 @@ function DatasheetSection({ section, baselineYear }: DatasheetSectionProps) {
                 return null;
               }
 
+              const bounds = row.suggestedBoundsByYear[year];
+              const rowWithBounds = {
+                ...row,
+                suggestedMinValue: bounds?.minValue ?? null,
+                suggestedMaxValue: bounds?.maxValue ?? null,
+              };
               return (
                 <CustomEditComponent<AdditionalDatasheetMeasureRow>
                   {...rest}
-                  row={row}
+                  row={rowWithBounds}
                   placeholder={getPlaceholder(row, year)}
                 />
               );

--- a/src/components/DatasheetEditor.tsx
+++ b/src/components/DatasheetEditor.tsx
@@ -25,6 +25,7 @@ import type {
   GridRenderCellParams,
   GridRenderEditCellParams,
   GridRowClassNameParams,
+  GridRowId,
   GridSlotsComponentsProps,
 } from '@mui/x-data-grid';
 import { DataGrid, GridCellModes, useGridApiContext } from '@mui/x-data-grid';
@@ -46,7 +47,7 @@ import type { Section } from '@/utils/measures';
 import {
   getDecimalPrecisionByUnit,
   getMeasureFallback,
-  getMeasureSuggestedBounds,
+  getMeasureProbableBounds,
   getMeasureValue,
   getUnitName,
   isYearMeasure,
@@ -207,39 +208,39 @@ export function formatNumericValue(
   });
 }
 
-function isOutOfSuggestedBounds(
+function isOutOfProbableBounds(
   value: number | null | undefined,
-  suggestedMinValue: number | null | undefined,
-  suggestedMaxValue: number | null | undefined
+  probableLowerBound: number | null | undefined,
+  probableUpperBound: number | null | undefined
 ): boolean {
   if (typeof value !== 'number') {
     return false;
   }
 
-  if (typeof suggestedMinValue === 'number' && value < suggestedMinValue) {
+  if (typeof probableLowerBound === 'number' && value < probableLowerBound) {
     return true;
   }
 
-  if (typeof suggestedMaxValue === 'number' && value > suggestedMaxValue) {
+  if (typeof probableUpperBound === 'number' && value > probableUpperBound) {
     return true;
   }
 
   return false;
 }
 
-function getSuggestedBoundsTooltip(
-  suggestedMinValue: number | null | undefined,
-  suggestedMaxValue: number | null | undefined,
+function getProbableBoundsTooltip(
+  probableLowerBound: number | null | undefined,
+  probableUpperBound: number | null | undefined,
   unit?: Partial<UnitType>
 ): string {
   const formattedUnit = unit?.long ?? '';
   const precision = unit ? getDecimalPrecisionByUnit(unit) : undefined;
 
-  const formattedMin = suggestedMinValue
-    ? suggestedMinValue.toLocaleString(undefined, { maximumFractionDigits: precision })
+  const formattedMin = probableLowerBound
+    ? probableLowerBound.toLocaleString(undefined, { maximumFractionDigits: precision })
     : null;
-  const formattedMax = suggestedMaxValue
-    ? suggestedMaxValue.toLocaleString(undefined, { maximumFractionDigits: precision })
+  const formattedMax = probableUpperBound
+    ? probableUpperBound.toLocaleString(undefined, { maximumFractionDigits: precision })
     : null;
 
   const suffix = 'Please check the value is correct and matches the specified unit.';
@@ -252,7 +253,7 @@ function getSuggestedBoundsTooltip(
     return `Value is below the expected minimum of ${formattedMin} ${formattedUnit}. ${suffix}`;
   }
 
-  if (typeof suggestedMaxValue === 'number') {
+  if (typeof probableUpperBound === 'number') {
     return `Value is above the expected maximum of ${formattedMax} ${formattedUnit}. ${suffix}`;
   }
 
@@ -289,14 +290,14 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
 
   const canEdit = permissions.edit && !permissions.isLocked;
 
-  const suggestedMinValue = row.type === 'MEASURE' ? row.suggestedMinValue : null;
-  const suggestedMaxValue = row.type === 'MEASURE' ? row.suggestedMaxValue : null;
+  const probableLowerBound = row.type === 'MEASURE' ? row.probableLowerBound : null;
+  const probableUpperBound = row.type === 'MEASURE' ? row.probableUpperBound : null;
   const showWarning =
     colDef.type === 'number' &&
-    isOutOfSuggestedBounds(
+    isOutOfProbableBounds(
       typeof value === 'number' ? value : null,
-      suggestedMinValue,
-      suggestedMaxValue
+      probableLowerBound,
+      probableUpperBound
     );
 
   const warningAdornment = showWarning ? (
@@ -304,9 +305,9 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
       <Tooltip
         arrow
         placement="top"
-        title={getSuggestedBoundsTooltip(
-          suggestedMinValue,
-          suggestedMaxValue,
+        title={getProbableBoundsTooltip(
+          probableLowerBound,
+          probableUpperBound,
           row.type === 'MEASURE' ? row.unit : undefined
         )}
       >
@@ -676,6 +677,43 @@ export function renderLabelCell(
   );
 }
 
+function NotesViewCell({
+  id,
+  field,
+  value,
+  isEditable,
+}: {
+  id: GridRowId;
+  field: string;
+  value: string;
+  isEditable: boolean | undefined;
+}) {
+  const apiRef = useGridApiContext();
+
+  function handleFocus() {
+    if (isEditable) {
+      apiRef.current.startCellEditMode({ id, field });
+    }
+  }
+
+  return (
+    <Typography
+      tabIndex={0}
+      onFocus={handleFocus}
+      variant="body2"
+      sx={{
+        m: 1,
+        fontSize: '0.9em',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        color: 'text.secondary',
+      }}
+    >
+      {value}
+    </Typography>
+  );
+}
+
 const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
   {
     display: 'flex',
@@ -794,6 +832,35 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     type: 'string',
     flex: 4,
     ...EDITABLE_COL,
+    /**
+     * In view mode, render static text instead of a multiline TextField.
+     * A multiline TextField uses TextareaAutosize (ResizeObserver) which creates
+     * a feedback loop with DataGrid's auto row height when long non-breaking text
+     * causes horizontal overflow, making the row shake it like a polaroid picture.
+     *
+     * This also allows the notes to be smaller and more subtle while not editing.
+     */
+    renderCell: ({ row, value, ...rest }: GridRenderCellParams<DatasheetEditorRow>) => {
+      if (row.type === 'SUM_PERCENT') {
+        return null;
+      }
+
+      if (!value) {
+        return (
+          <CustomEditComponent
+            key={`${rest.field}-${row.id}`}
+            row={row}
+            value={value}
+            {...rest}
+            sx={{ mx: 0, my: 1 }}
+          />
+        );
+      }
+
+      return (
+        <NotesViewCell id={rest.id} field={rest.field} value={value as string} isEditable={rest.isEditable} />
+      );
+    },
   },
 ];
 
@@ -807,8 +874,8 @@ export type BaseMeasureRow = {
   depth: number;
   helpText: string | null;
   originalMeasureTemplate: MeasureTemplateFragmentFragment;
-  suggestedMinValue: number | null;
-  suggestedMaxValue: number | null;
+  probableLowerBound: number | null;
+  probableUpperBound: number | null;
 };
 
 export type MeasureRow = BaseMeasureRow & {
@@ -925,7 +992,7 @@ function getRowsFromSection(
   return [
     ...(isRoot ? [] : [sectionRow]),
     ...measureTemplates.map((measure): MeasureRow => {
-      const { suggestedMinValue, suggestedMaxValue } = getMeasureSuggestedBounds(
+      const { probableLowerBound, probableUpperBound } = getMeasureProbableBounds(
         measure,
         baselineYear
       );
@@ -944,8 +1011,8 @@ function getRowsFromSection(
         notes: measure.measure?.internalNotes ?? null,
         depth: depth + 1,
         originalMeasureTemplate: measure,
-        suggestedMinValue,
-        suggestedMaxValue,
+        probableLowerBound,
+        probableUpperBound,
       };
     }),
     ...(sectionRow.sumMeasureValues

--- a/src/components/DatasheetEditor.tsx
+++ b/src/components/DatasheetEditor.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Fade,
   Grid,
+  InputAdornment,
   Accordion as MuiAccordion,
   AccordionDetails as MuiAccordionDetails,
   AccordionSummary as MuiAccordionSummary,
@@ -37,6 +38,7 @@ import { useDataCollectionStore } from '@/store/data-collection';
 import type {
   FrameworksMeasureTemplatePriorityChoices,
   MeasureTemplateFragmentFragment,
+  UnitType,
   UpdateMeasureDataPointMutation,
   UpdateMeasureDataPointMutationVariables,
 } from '@/types/__generated__/graphql';
@@ -44,6 +46,7 @@ import type { Section } from '@/utils/measures';
 import {
   getDecimalPrecisionByUnit,
   getMeasureFallback,
+  getMeasureSuggestedBounds,
   getMeasureValue,
   getUnitName,
   isYearMeasure,
@@ -193,7 +196,7 @@ export function formatNumericValue(
     return '-';
   }
 
-  const precision = getDecimalPrecisionByUnit(row.unit.standard);
+  const precision = getDecimalPrecisionByUnit(row.unit);
 
   if (isYearMeasure(row.label, row.unit.short)) {
     return Math.round(value).toString();
@@ -202,6 +205,58 @@ export function formatNumericValue(
   return value.toLocaleString(undefined, {
     maximumFractionDigits: precision,
   });
+}
+
+function isOutOfSuggestedBounds(
+  value: number | null | undefined,
+  suggestedMinValue: number | null | undefined,
+  suggestedMaxValue: number | null | undefined
+): boolean {
+  if (typeof value !== 'number') {
+    return false;
+  }
+
+  if (typeof suggestedMinValue === 'number' && value < suggestedMinValue) {
+    return true;
+  }
+
+  if (typeof suggestedMaxValue === 'number' && value > suggestedMaxValue) {
+    return true;
+  }
+
+  return false;
+}
+
+function getSuggestedBoundsTooltip(
+  suggestedMinValue: number | null | undefined,
+  suggestedMaxValue: number | null | undefined,
+  unit?: Partial<UnitType>
+): string {
+  const formattedUnit = unit?.long ?? '';
+  const precision = unit ? getDecimalPrecisionByUnit(unit) : undefined;
+
+  const formattedMin = suggestedMinValue
+    ? suggestedMinValue.toLocaleString(undefined, { maximumFractionDigits: precision })
+    : null;
+  const formattedMax = suggestedMaxValue
+    ? suggestedMaxValue.toLocaleString(undefined, { maximumFractionDigits: precision })
+    : null;
+
+  const suffix = 'Please check the value is correct and matches the specified unit.';
+
+  if (formattedMin && formattedMax) {
+    return `Value is outside the expected range. Expected: ${formattedMin}-${formattedMax} ${formattedUnit}. ${suffix}`;
+  }
+
+  if (formattedMin) {
+    return `Value is below the expected minimum of ${formattedMin} ${formattedUnit}. ${suffix}`;
+  }
+
+  if (typeof suggestedMaxValue === 'number') {
+    return `Value is above the expected maximum of ${formattedMax} ${formattedUnit}. ${suffix}`;
+  }
+
+  return '';
 }
 
 type CustomEditComponentProps<TMeasureRow extends BaseMeasureRow = MeasureRow> =
@@ -233,6 +288,37 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
   const [key, setKey] = useState(0);
 
   const canEdit = permissions.edit && !permissions.isLocked;
+
+  const suggestedMinValue = row.type === 'MEASURE' ? row.suggestedMinValue : null;
+  const suggestedMaxValue = row.type === 'MEASURE' ? row.suggestedMaxValue : null;
+  const showWarning =
+    colDef.type === 'number' &&
+    isOutOfSuggestedBounds(
+      typeof value === 'number' ? value : null,
+      suggestedMinValue,
+      suggestedMaxValue
+    );
+
+  const warningAdornment = showWarning ? (
+    <InputAdornment position="end">
+      <Tooltip
+        arrow
+        placement="top"
+        title={getSuggestedBoundsTooltip(
+          suggestedMinValue,
+          suggestedMaxValue,
+          row.type === 'MEASURE' ? row.unit : undefined
+        )}
+      >
+        <Box
+          component="span"
+          sx={{ display: 'flex', color: 'warning.main', cursor: 'default', pointerEvents: 'auto' }}
+        >
+          <ExclamationTriangle size={14} />
+        </Box>
+      </Tooltip>
+    </InputAdornment>
+  ) : null;
 
   useLayoutEffect(() => {
     if (hasFocus && canEdit && ref.current) {
@@ -293,16 +379,15 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
         fullWidth
         placeholder={placeholder || undefined}
         onKeyDown={handleEscape}
-        onValueChange={
-          canEdit ? (value) => void handleNumberValueChange(value) : undefined
-        }
+        onValueChange={canEdit ? (value) => void handleNumberValueChange(value) : undefined}
         defaultValue={typeof initialValue.current === 'number' ? initialValue.current : ''}
         disabled={!canEdit}
         inputProps={{
           'aria-label': `${row.label} ${field}`,
-          decimalScale: getDecimalPrecisionByUnit(row.unit.standard),
+          decimalScale: getDecimalPrecisionByUnit(row.unit),
           ...(isYearMeasure(row.label, row.unit.long) ? yearInputProps : {}),
         }}
+        InputProps={warningAdornment ? { endAdornment: warningAdornment } : undefined}
       />
     ) : (
       <TextField
@@ -675,7 +760,7 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
         return undefined;
       }
 
-      const precision = getDecimalPrecisionByUnit(row.unit.standard);
+      const precision = getDecimalPrecisionByUnit(row.unit);
 
       if (isYearMeasure(row.label, row.unit.long)) {
         return Math.round(value);
@@ -722,6 +807,8 @@ export type BaseMeasureRow = {
   depth: number;
   helpText: string | null;
   originalMeasureTemplate: MeasureTemplateFragmentFragment;
+  suggestedMinValue: number | null;
+  suggestedMaxValue: number | null;
 };
 
 export type MeasureRow = BaseMeasureRow & {
@@ -837,8 +924,13 @@ function getRowsFromSection(
 
   return [
     ...(isRoot ? [] : [sectionRow]),
-    ...measureTemplates.flatMap(
-      (measure): MeasureRow => ({
+    ...measureTemplates.map((measure): MeasureRow => {
+      const { suggestedMinValue, suggestedMaxValue } = getMeasureSuggestedBounds(
+        measure,
+        baselineYear
+      );
+
+      return {
         isTitle: false,
         type: 'MEASURE',
         id: measure.uuid,
@@ -852,8 +944,10 @@ function getRowsFromSection(
         notes: measure.measure?.internalNotes ?? null,
         depth: depth + 1,
         originalMeasureTemplate: measure,
-      })
-    ),
+        suggestedMinValue,
+        suggestedMaxValue,
+      };
+    }),
     ...(sectionRow.sumMeasureValues
       ? [
           getSumPercentRow(

--- a/src/components/DatasheetEditor.tsx
+++ b/src/components/DatasheetEditor.tsx
@@ -681,7 +681,7 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     display: 'flex',
     headerName: 'Label',
     field: 'label',
-    flex: 2,
+    flex: 4,
     renderCell: (params: GridRenderCellParams<DatasheetEditorRow>) =>
       renderLabelCell(
         params.row.type,
@@ -705,14 +705,14 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     type: 'number',
     headerAlign: 'left',
     align: 'left',
-    flex: 1,
+    flex: 3,
     ...EDITABLE_COL,
   },
   {
     display: 'flex',
     headerName: 'Unit',
     field: 'unit',
-    flex: 1,
+    flex: 2,
     valueFormatter: (value: UnitFragment, row: MeasureRow | SumPercentRow) =>
       row.type === 'MEASURE' ? value.long : undefined,
     renderCell: (params: GridRenderCellParams<DatasheetEditorRow>) => {
@@ -737,7 +737,7 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     description:
       'Comparable City Values are developed based on the 3 questions you answered when you created your plan. 1) Population, 2) Climate 3) % Zero Carbon Electricity. The system averages the data for European cities that have similar Climate and % Zero Carbon Electricity and then adjusts for the exact population of your city. Comparable City Values can be used to validate your own data inputs. If you have no information for a given cell, you can leave that cell blank, and the system will default to the Comparable City Value.',
     field: 'fallback',
-    flex: 1,
+    flex: 2,
     renderCell: (params: GridRenderCellParams<DatasheetEditorRow>) => {
       if (params.row.type === 'SUM_PERCENT') {
         return (
@@ -775,7 +775,7 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     display: 'flex',
     headerName: 'Priority',
     field: 'priority',
-    flex: 1,
+    flex: 2,
     minWidth: 90,
     renderHeader: ({ colDef }) => (
       <HeaderWithHelpText headerName={colDef.headerName!} helpText={colDef.description!} />
@@ -792,7 +792,7 @@ const GRID_COL_DEFS: GridColDef<DatasheetEditorRow>[] = [
     headerName: 'Internal Notes',
     field: 'notes',
     type: 'string',
-    flex: 2,
+    flex: 4,
     ...EDITABLE_COL,
   },
 ];

--- a/src/queries/framework/get-framework-config.ts
+++ b/src/queries/framework/get-framework-config.ts
@@ -11,8 +11,8 @@ export const GET_FRAMEWORK_CONFIG = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        # instanceIdentifier
-        # isLocked
+        instanceIdentifier
+        isLocked
       }
     }
   }
@@ -29,8 +29,8 @@ export const GET_FRAMEWORK_CONFIGS = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        # instanceIdentifier
-        # isLocked
+        instanceIdentifier
+        isLocked
       }
     }
   }

--- a/src/queries/framework/get-framework-config.ts
+++ b/src/queries/framework/get-framework-config.ts
@@ -11,8 +11,8 @@ export const GET_FRAMEWORK_CONFIG = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        instanceIdentifier
-        isLocked
+        # instanceIdentifier
+        # isLocked
       }
     }
   }
@@ -29,8 +29,8 @@ export const GET_FRAMEWORK_CONFIGS = gql`
         targetYear
         viewUrl
         resultsDownloadUrl
-        instanceIdentifier
-        isLocked
+        # instanceIdentifier
+        # isLocked
       }
     }
   }

--- a/src/queries/get-measure-template.ts
+++ b/src/queries/get-measure-template.ts
@@ -16,6 +16,8 @@ export const GET_MEASURE_TEMPLATE = gql`
             value
             year
             defaultValue
+            # minValue TODO: Add when backend ready
+            # maxValue TODO: Add when backend ready
           }
         }
       }

--- a/src/queries/get-measure-template.ts
+++ b/src/queries/get-measure-template.ts
@@ -16,8 +16,8 @@ export const GET_MEASURE_TEMPLATE = gql`
             value
             year
             defaultValue
-            # minValue TODO: Add when backend ready
-            # maxValue TODO: Add when backend ready
+            probableLowerBound
+            probableUpperBound
           }
         }
       }

--- a/src/queries/update-measure-datapoint.ts
+++ b/src/queries/update-measure-datapoint.ts
@@ -9,6 +9,8 @@ export const measureDataPointFragment = gql`
     value
     year
     defaultValue
+    # minValue TODO: Add when backend ready
+    # maxValue TODO: Add when backend ready
   }
 `;
 

--- a/src/queries/update-measure-datapoint.ts
+++ b/src/queries/update-measure-datapoint.ts
@@ -9,8 +9,8 @@ export const measureDataPointFragment = gql`
     value
     year
     defaultValue
-    # minValue TODO: Add when backend ready
-    # maxValue TODO: Add when backend ready
+    probableLowerBound
+    probableUpperBound
   }
 `;
 

--- a/src/types/__generated__/graphql.ts
+++ b/src/types/__generated__/graphql.ts
@@ -1049,6 +1049,7 @@ export type FrameworkSectionArgs = {
 export type FrameworkConfig = {
   __typename?: 'FrameworkConfig';
   baselineYear: Scalars['Int']['output'];
+  extra: Scalars['JSONString']['output'];
   framework: Framework;
   id: Scalars['ID']['output'];
   instance?: Maybe<InstanceType>;
@@ -1102,6 +1103,12 @@ export type FrameworkLandingBlock = StreamFieldInterface & {
   id?: Maybe<Scalars['String']['output']>;
   rawValue: Scalars['String']['output'];
 };
+
+/** An enumeration. */
+export enum FrameworksMeasureTemplateDefaultValueScalingChoices {
+  /** Population */
+  Population = 'POPULATION'
+}
 
 /** An enumeration. */
 export enum FrameworksMeasureTemplatePriorityChoices {
@@ -1252,6 +1259,7 @@ export type ImpactOverviewType = {
   outcomeDimension?: Maybe<Scalars['String']['output']>;
   plotLimitForIndicator?: Maybe<Scalars['Float']['output']>;
   stakeholderDimension?: Maybe<Scalars['String']['output']>;
+  wedge?: Maybe<Array<WedgeEntryType>>;
 };
 
 export type InputPortBindingUnion = DatasetPortType | NodeEdgeType;
@@ -1743,6 +1751,8 @@ export type MeasureDataPoint = {
   __typename?: 'MeasureDataPoint';
   defaultValue?: Maybe<Scalars['Float']['output']>;
   id: Scalars['ID']['output'];
+  probableLowerBound?: Maybe<Scalars['Float']['output']>;
+  probableUpperBound?: Maybe<Scalars['Float']['output']>;
   userPermissions?: Maybe<UserPermissions>;
   userRoles?: Maybe<Array<Scalars['String']['output']>>;
   value?: Maybe<Scalars['Float']['output']>;
@@ -1778,6 +1788,7 @@ export type MeasureInput = {
 export type MeasureTemplate = {
   __typename?: 'MeasureTemplate';
   defaultDataPoints: Array<MeasureTemplateDefaultDataPoint>;
+  defaultValueScaling?: Maybe<FrameworksMeasureTemplateDefaultValueScalingChoices>;
   defaultValueSource: Scalars['String']['output'];
   helpText: Scalars['String']['output'];
   hidden: Scalars['Boolean']['output'];
@@ -1822,6 +1833,8 @@ export type MeasureTemplateMeasureArgs = {
 export type MeasureTemplateDefaultDataPoint = {
   __typename?: 'MeasureTemplateDefaultDataPoint';
   id: Scalars['ID']['output'];
+  probableLowerBound?: Maybe<Scalars['Float']['output']>;
+  probableUpperBound?: Maybe<Scalars['Float']['output']>;
   userPermissions?: Maybe<UserPermissions>;
   userRoles?: Maybe<Array<Scalars['String']['output']>>;
   value: Scalars['Float']['output'];
@@ -3311,6 +3324,14 @@ export type VisualizationNodeOutput = VisualizationEntry & {
   scenarios?: Maybe<Array<Scalars['String']['output']>>;
 };
 
+export type WedgeEntryType = {
+  __typename?: 'WedgeEntryType';
+  id: Scalars['ID']['output'];
+  isScenario: Scalars['Boolean']['output'];
+  label: Scalars['String']['output'];
+  metric: DimensionalMetricType;
+};
+
 export type YearlyValue = {
   __typename?: 'YearlyValue';
   value: Scalars['Float']['output'];
@@ -3491,7 +3512,7 @@ export type GetMeasureTemplateQuery = (
     { id: string, measureTemplate?: (
       { id: string, uuid: string, name: string, measure?: (
         { id: string, internalNotes: string, dataPoints: Array<(
-          { id: string, value?: number | null, year: number, defaultValue?: number | null }
+          { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
           & { __typename?: 'MeasureDataPoint' }
         )> }
         & { __typename?: 'Measure' }
@@ -3531,7 +3552,7 @@ export type GetMeasureTemplatesQuery = (
               { year?: number | null, value?: number | null }
               & { __typename: 'PlaceHolderDataPoint' }
             ) | null> | null, dataPoints: Array<(
-              { id: string, value?: number | null, year: number, defaultValue?: number | null }
+              { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
               & { __typename: 'MeasureDataPoint' }
             )> }
             & { __typename: 'Measure' }
@@ -3561,7 +3582,7 @@ export type GetMeasureTemplatesQuery = (
               { year?: number | null, value?: number | null }
               & { __typename: 'PlaceHolderDataPoint' }
             ) | null> | null, dataPoints: Array<(
-              { id: string, value?: number | null, year: number, defaultValue?: number | null }
+              { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
               & { __typename: 'MeasureDataPoint' }
             )> }
             & { __typename: 'Measure' }
@@ -3600,7 +3621,7 @@ export type MainSectionMeasuresFragment = (
           { year?: number | null, value?: number | null }
           & { __typename: 'PlaceHolderDataPoint' }
         ) | null> | null, dataPoints: Array<(
-          { id: string, value?: number | null, year: number, defaultValue?: number | null }
+          { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
           & { __typename: 'MeasureDataPoint' }
         )> }
         & { __typename: 'Measure' }
@@ -3631,7 +3652,7 @@ export type SectionFragmentFragment = (
         { year?: number | null, value?: number | null }
         & { __typename: 'PlaceHolderDataPoint' }
       ) | null> | null, dataPoints: Array<(
-        { id: string, value?: number | null, year: number, defaultValue?: number | null }
+        { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
         & { __typename: 'MeasureDataPoint' }
       )> }
       & { __typename: 'Measure' }
@@ -3653,7 +3674,7 @@ export type MeasureTemplateFragmentFragment = (
       { year?: number | null, value?: number | null }
       & { __typename: 'PlaceHolderDataPoint' }
     ) | null> | null, dataPoints: Array<(
-      { id: string, value?: number | null, year: number, defaultValue?: number | null }
+      { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
       & { __typename: 'MeasureDataPoint' }
     )> }
     & { __typename: 'Measure' }
@@ -3698,7 +3719,7 @@ export type GetMeasuresQuery = (
 );
 
 export type DataPointFragmentFragment = (
-  { id: string, value?: number | null, year: number, defaultValue?: number | null }
+  { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
   & { __typename: 'MeasureDataPoint' }
 );
 
@@ -3714,7 +3735,7 @@ export type UpdateMeasureDataPointMutationVariables = Exact<{
 export type UpdateMeasureDataPointMutation = (
   { updateMeasureDataPoint?: (
     { measureDataPoint?: (
-      { id: string, value?: number | null, year: number, defaultValue?: number | null }
+      { id: string, value?: number | null, year: number, defaultValue?: number | null, probableLowerBound?: number | null, probableUpperBound?: number | null }
       & { __typename: 'MeasureDataPoint' }
     ) | null }
     & { __typename?: 'UpdateMeasureDataPoint' }

--- a/src/utils/measures.tsx
+++ b/src/utils/measures.tsx
@@ -6,6 +6,7 @@ import type {
   MainSectionMeasuresFragment,
   MeasureFragmentFragment,
   MeasureTemplateFragmentFragment,
+  UnitType,
 } from '@/types/__generated__/graphql';
 
 import { createFilterByTypename } from './filter';
@@ -128,6 +129,27 @@ export function getMeasureValue(
   return null;
 }
 
+export function getMeasureSuggestedBounds(
+  measureTemplate: MeasureTemplateFragmentFragment,
+  baselineYear: number | null
+): { suggestedMinValue: number | null; suggestedMaxValue: number | null } {
+  const dataPoints = measureTemplate.measure?.dataPoints;
+
+  if (!dataPoints?.length) {
+    return { suggestedMinValue: null, suggestedMaxValue: null };
+  }
+
+  const dataPoint =
+    baselineYear != null
+      ? (dataPoints.find((dp) => dp.year === baselineYear) ?? dataPoints[0])
+      : dataPoints[0];
+
+  return {
+    suggestedMinValue: 200, // dataPoint?.minValue ?? null, // TODO: Update when backend ready
+    suggestedMaxValue: 1000, // dataPoint?.maxValue ?? null,// TODO: Update when backend ready
+  };
+}
+
 export function getMeasureFallback(
   measureTemplate: MeasureTemplateFragmentFragment,
   baselineYear: number | null
@@ -183,8 +205,10 @@ export type ExportedDataV2 = {
  * the appropriate decimal precision for various units. If the unit is not found
  * in the mapping, it returns undefined.
  */
-export function getDecimalPrecisionByUnit(unit: string): number | undefined {
-  return DECIMAL_PRECISION_BY_UNIT[unit as keyof typeof DECIMAL_PRECISION_BY_UNIT] ?? undefined;
+export function getDecimalPrecisionByUnit(unit: Partial<UnitType>): number | undefined {
+  return (
+    DECIMAL_PRECISION_BY_UNIT[unit.standard as keyof typeof DECIMAL_PRECISION_BY_UNIT] ?? undefined
+  );
 }
 
 export function getUnitName(unit: string): ReactNode {

--- a/src/utils/measures.tsx
+++ b/src/utils/measures.tsx
@@ -129,14 +129,14 @@ export function getMeasureValue(
   return null;
 }
 
-export function getMeasureSuggestedBounds(
+export function getMeasureProbableBounds(
   measureTemplate: MeasureTemplateFragmentFragment,
   baselineYear: number | null
-): { suggestedMinValue: number | null; suggestedMaxValue: number | null } {
+): { probableLowerBound: number | null; probableUpperBound: number | null } {
   const dataPoints = measureTemplate.measure?.dataPoints;
 
   if (!dataPoints?.length) {
-    return { suggestedMinValue: null, suggestedMaxValue: null };
+    return { probableLowerBound: null, probableUpperBound: null };
   }
 
   const dataPoint =
@@ -145,8 +145,8 @@ export function getMeasureSuggestedBounds(
       : dataPoints[0];
 
   return {
-    suggestedMinValue: 200, // dataPoint?.minValue ?? null, // TODO: Update when backend ready
-    suggestedMaxValue: 1000, // dataPoint?.maxValue ?? null,// TODO: Update when backend ready
+    probableLowerBound: dataPoint?.probableLowerBound ?? null,
+    probableUpperBound: dataPoint?.probableUpperBound ?? null,
   };
 }
 


### PR DESCRIPTION
## Description
Update the grid editor so that values outside of a specific range per measure are highlighted. The goal of this is to proactively show the user where they may have entered some wrong data.

## Screenshots/Videos (if applicable)

### Invalid value (absolute min/ max)
This functionality already exists, if a value is out of its logical min/max values we validate it on the UI and prevent it from being saved.

<img width="1222" height="557" alt="image" src="https://github.com/user-attachments/assets/329ea192-f423-4ab5-b90a-f3798338affd" />

### Abnormal value (suggested min/max)
If a value is outside the suggested bounds, we save it as normal but display a warning sign next to the value.

<img width="1104" height="484" alt="image" src="https://github.com/user-attachments/assets/d78f32c4-61c8-4da6-bc23-851e498b554b" />

## Requirements, dependencies and related PRs
The backend is still a WIP, the min/ max values have been mocked and this shouldn't be merged until the backend is ready.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Mobile screen widths tested for responsiveness** (if applicable)
- [ ] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs)
