### PR TITLE
Enforce strict limits when forming the probable bounds message

### DIFF
--- a/src/components/DatasheetEditor.tsx
+++ b/src/components/DatasheetEditor.tsx
@@ -228,6 +228,28 @@ function isOutOfProbableBounds(
   return false;
 }
 
+function getProbableOrStrictBound(
+  bound: 'lower' | 'upper',
+  probable?: number | null,
+  strict?: number | null
+) {
+  const minOrMax = bound === 'lower' ? Math.max : Math.min;
+
+  if (typeof probable === 'number' && typeof strict === 'number') {
+    return minOrMax(probable, strict);
+  }
+
+  if (typeof strict === 'number') {
+    return strict;
+  }
+
+  if (typeof probable === 'number') {
+    return probable;
+  }
+
+  return null;
+}
+
 function getProbableBoundsTooltip(
   violation: 'below' | 'above',
   probableLowerBound: number | null | undefined,
@@ -285,8 +307,23 @@ export default function CustomEditComponent<TMeasureRow extends BaseMeasureRow =
 
   const canEdit = permissions.edit && !permissions.isLocked;
 
-  const probableLowerBound = row.type === 'MEASURE' ? row.probableLowerBound : null;
-  const probableUpperBound = row.type === 'MEASURE' ? row.probableUpperBound : null;
+  const probableLowerBound =
+    row.type === 'MEASURE'
+      ? getProbableOrStrictBound(
+          'lower',
+          row.probableLowerBound,
+          row.originalMeasureTemplate.minValue
+        )
+      : null;
+  const probableUpperBound =
+    row.type === 'MEASURE'
+      ? getProbableOrStrictBound(
+          'upper',
+          row.probableUpperBound,
+          row.originalMeasureTemplate.maxValue
+        )
+      : null;
+
   const boundsViolation =
     colDef.type === 'number'
       ? isOutOfProbableBounds(


### PR DESCRIPTION
## Description
Previously, if a measure had a strict limit (e.g. `minValue`) and a suggested limit (e.g. `probableLowerBound`), and the suggested limit was higher/ lower than the strict limit, it was incorrectly used in the message. Fix this so that the strict bounds are considered when forming the message.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [-] **Mobile screen widths tested for responsiveness** (if applicable)
- [x] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs)
